### PR TITLE
fix some 'extern function()' declaration

### DIFF
--- a/comuni.c
+++ b/comuni.c
@@ -237,8 +237,8 @@ open_af_inet(void)
 	struct opthdr *hdr;
         void *handlep;
         extern int t_errno;
-        extern void *setnetpath();
-        extern struct netconfig *getnetpath();
+        extern void *setnetpath(void);
+        extern struct netconfig *getnetpath(void *);
 #else
 	struct sockaddr_in	sin;
 	struct servent	*sp;

--- a/configure
+++ b/configure
@@ -82,8 +82,7 @@ fi
 AR=`printf "all:\\n\\t@echo \\\$(AR)\\n" | make ${MAKE_FLAGS} -sf -`
 CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | make ${MAKE_FLAGS} -sf -`
 CFLAGS=`printf "all:\\n\\t@echo \\\$(CFLAGS)\\n" | make ${MAKE_FLAGS} -sf -`
-CFLAGS="${CFLAGS} -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes"
-CFLAGS="${CFLAGS} -Wwrite-strings -Wno-unused-parameter"
+CFLAGS="${CFLAGS} -g -Wall -Wextra"
 LDLIBS=
 LDADD=
 LDADD_B64_NTOP=

--- a/dictmake.c
+++ b/dictmake.c
@@ -61,7 +61,6 @@ char	*y, *k, *h;
 	int	err;
 	int	grm;
 	unsigned char buf[BUFSIZ], *hp;
-	extern int sjistoeuc();
 
 	if (_sys_code == SYS_SJIS) {
 		(void) sjistoeuc(buf, BUFSIZ, h, strlen(h)+1);

--- a/rk_conv.c
+++ b/rk_conv.c
@@ -1076,7 +1076,7 @@ int wlen;
 
 
 
-extern int sj3_rkconv_w16();
+int sj3_rkconv_w16(wchar16_t *, wchar16_t *);
 
 sj3_rkconv(romaji, kana)
 u_char *romaji;
@@ -1180,7 +1180,7 @@ u_char *kana;
 	  return sj3_rkconv(romaji, kana);
 }
 
-sj3_rkconv_w16(wstr, kstr)
+int sj3_rkconv_w16(wstr, kstr)
 wchar16_t *wstr;
 wchar16_t *kstr;
 {

--- a/setup.c
+++ b/setup.c
@@ -459,7 +459,7 @@ parse_arg(int argc, char** argv)
 	char	*p;
 	size_t	ret;
 
-	extern	char	*optarg, *strrchr();
+	extern	char	*optarg;
 	extern	int	optind;
 
 	p = (p = strrchr(argv[0], '/')) ? p + 1 : argv[0];

--- a/sj3.c
+++ b/sj3.c
@@ -99,7 +99,7 @@ char	slave_name[SHORTLENGTH];
 char	*shellargs[SHORTLENGTH];	
 #ifdef SVR4
 char	*mptname = "/dev/ptmx";		
-char    *ptsname();
+char    *ptsname(int);
 #else
 static char	line[SHORTLENGTH];		
 #endif

--- a/sj3_rkcv.c
+++ b/sj3_rkcv.c
@@ -286,7 +286,7 @@ u_short c;
 }
 
 
-extern int sj3_hantozen_w16();
+int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
 
 sj3_hantozen(out, in)
 u_char *out, *in;
@@ -483,7 +483,7 @@ u_char *s1, *s2;
   	  return sj3_hantozen(s1, s2);
 }
 
-sj3_hantozen_w16(s1, s2)
+int sj3_hantozen_w16(s1, s2)
 wchar16_t *s1, *s2;
 {
 	return sj_hantozen(s1, s2, wslen(s2));
@@ -559,7 +559,7 @@ u_short c;
 	return(cc);
 }
 
-extern int sj3_zentohan_w16();
+int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
 
 sj3_zentohan(out, in)
 u_char *out, *in;
@@ -751,7 +751,7 @@ u_char *s1, *s2;
 	  return sj3_zentohan(s1, s2);
 }
 
-sj3_zentohan_w16 (s1, s2)
+int sj3_zentohan_w16 (s1, s2)
 wchar16_t *s1, *s2;
 {
 	return sj_zentohan(s1, s2, wslen(s2));

--- a/sj3dic.c
+++ b/sj3dic.c
@@ -182,7 +182,6 @@ parsearg(int argc, char* argv[])
 	int	cmd;
 	int	mode = 0;
 	char	tmp[LONGLENGTH];
-	extern char *strrchr();
 
 	strcpy(prog_name, (p = strrchr(argv[0], '/')) ? p + 1 : argv[0]);
 

--- a/sjgetchar.c
+++ b/sjgetchar.c
@@ -116,7 +116,7 @@ static char stopc = CTRL('s');
 static char startc = CTRL('q');
 static char outbuf[BUFSIZ];
 extern int slave;
-extern char *slave_name, *ptsname();
+extern char *slave_name, *ptsname(int);
 
 output_master()
 {


### PR DESCRIPTION
この修正、eucmessage.cの
```
extern int   set_func(), set_etckeys(), set_intr(),
        set_delkey(), set_goto(), set_trap(), set_init_mode(),
        set_helpmenu(), set_defcode(), set_muhenkan(), set_muedit(),
        set_m_toggle(), set_guide(), set_forkshell(), set_bstudy(),
        set_silent(), set_flush_conversion(), set_rkebell(), set_server(),
        set_dict();
```
も併せて行いたいのですが、未着手です。

set_func(), set_etckeys()は#include "sj3.h"の追加で対応できます。
他については全てsjrc2.cの関数であり、これを呼び出せるよう既にあるヘッダファイルに追加するなり、新規にヘッダファイルを起こす必要があります。
（sjrc.cもset_dict(), set_server()を読んでいるので、sjrc2.hを用意するのが良さそうですがライセンスの文言を考えるのが少し手間ですね…）

setnetpath()周りは#ifdef TLI有効時のコードになるため、TLIを使わなければばっさり切ることも考える必要があります。現状ではとりあえず直してみた以上の意味はありません。#ifdef SVR4も要るのかどうか…