### PR TITLE
revise sj_typedef.h

### DIFF
--- a/adddic.c
+++ b/adddic.c
@@ -171,7 +171,7 @@ adddic(u_char* yomi, u_char* kanji, TypeGram  hinsi)
 			curdict->segunit++;
 
 			(*curdict->getdic)(curdict, curdict->segunit - 1);
-			memset(dicbuf, DicSegTerm, (Int)curdict->seglen);
+			memset(dicbuf, DicSegTerm, (int)curdict->seglen);
 			dicbuf[0] = 0;
 			(*curdict->putdic)(curdict, curdict->segunit - 1);
 			(*curdict->rszdic)(curdict, curdict->segunit);
@@ -264,7 +264,7 @@ adddic(u_char* yomi, u_char* kanji, TypeGram  hinsi)
 
 		for (p1 = ClStudyDict ; !iseocl(p1) ; p1 = ClNextTag(p1)) {
 			err = strncmp(yptr, (u_char*)ClYomiPos(p1),
-					(Int)ClYomiLen(p1));
+					(int)ClYomiLen(p1));
 			if (err == MATCH) {
 				delclsub(p1);		
 				mkclidx();		
@@ -287,7 +287,7 @@ adddic(u_char* yomi, u_char* kanji, TypeGram  hinsi)
 	stdydat.sttlen       = 0;
 	stdydat.sttfg        = 0;
 	stdydat.ka_fg        = 0;
-	(Void)study(&stdydat);
+	(void)study(&stdydat);
 
 	return AD_Done;
 }
@@ -468,7 +468,7 @@ sprt_seg(TypeDicSeg seg, TypeDicOfs ofs)
 	}
 
 	(*curdict->getdic)(curdict, seg);
-	memset(dicbuf + ofs, DicSegTerm, (Int)(curdict->seglen - ofs));
+	memset(dicbuf + ofs, DicSegTerm, (int)(curdict->seglen - ofs));
 	(*curdict->putdic)(curdict, seg);
 }
 
@@ -483,7 +483,7 @@ apnd_uidx(TypeDicSeg seg, u_char* yomi, int len)
 	while (*p++) ;
 
 	q = idxbuf + curdict->idxlen;
-	mvmemd(q - (len + 1), q, (Int)(q - (len + 1) - p));
+	mvmemd(q - (len + 1), q, (int)(q - (len + 1) - p));
 
 	while (len--) *p++ = *yomi++;
 	*p = 0;

--- a/addelcmn.c
+++ b/addelcmn.c
@@ -44,27 +44,27 @@
 #include "kanakan.h"
 
 
-Int	sj2cd_str();
-Void	mvmemi(), mvmemd(), mkidxtbl();
+int	sj2cd_str();
+void	mvmemi(), mvmemd(), mkidxtbl();
 
 
 
 void
-set_size (Uchar *p, Int size, Int plen, Int nlen)
+set_size (u_char *p, int size, int plen, int nlen)
 {
-	*p = (Uchar)(size >> 8);
+	*p = (u_char)(size >> 8);
 	if (nlen & 0x10) *p |= NokoriYomiTop;
 	if (plen & 0x10) *p |= AssyukuYomiTop;
-	*(p + 1) = (Uchar)size;
-	*(p + 2) = (Uchar)((nlen & 0x0f) | ((plen & 0x0f) << 4));
+	*(p + 1) = (u_char)size;
+	*(p + 2) = (u_char)((nlen & 0x0f) | ((plen & 0x0f) << 4));
 }
 
 
 
-static	Int
-isvyomi (Uchar *yp)
+static	int
+isvyomi (u_char *yp)
 {
-	Int	len;
+	int	len;
 
 	if (!*yp) return FALSE;	
 
@@ -80,10 +80,10 @@ isvyomi (Uchar *yp)
 
 
 
-static	Int
-isvknj(Uchar *kanji)
+static	int
+isvknj(u_char *kanji)
 {
-	Int	len;
+	int	len;
 
 	if (!*kanji) return FALSE; 	
 
@@ -110,10 +110,10 @@ isvknj(Uchar *kanji)
 
 
 
-static	Int
+static	int
 isgrm (TypeGram gram)
 {
-	Int	grm = gram;
+	int	grm = gram;
 
 	if (MEISI_1    <= grm && grm <= D_MEISI_6)  return TRUE;
 	if (MYOUJI     <= grm && grm <= JOSUUSI2)   return TRUE;
@@ -132,10 +132,10 @@ isgrm (TypeGram gram)
 
 
 
-Uint
-addel_arg (Uchar *yp, Uchar *kp, TypeGram grm, Uchar *nyp, Int len)
+u_int
+addel_arg (u_char *yp, u_char *kp, TypeGram grm, u_char *nyp, int len)
 {
-	Ushort	err = 0;
+	u_short	err = 0;
 
 	if (!sj2cd_str(yp, nyp, len)) err |= AD_BadYomi;
 	if (!isvyomi(nyp)) err |= AD_BadYomi;
@@ -147,10 +147,10 @@ addel_arg (Uchar *yp, Uchar *kp, TypeGram grm, Uchar *nyp, Int len)
 
 
 static	void
-yomi2kata (Uchar *src, Uchar *dst)
+yomi2kata (u_char *src, u_char *dst)
 {
-	Int	first;
-	Int	second;
+	int	first;
+	int	second;
 
 	while ((first = *src++) != 0) {
 		second = *src++;
@@ -170,10 +170,10 @@ yomi2kata (Uchar *src, Uchar *dst)
 
 
 
-static	Int
-top_strcmp (Uchar *src, Uchar *dst)
+static	int
+top_strcmp (u_char *src, u_char *dst)
 {
-	Int	i;
+	int	i;
 	for (i = 0 ; *src && (*src == *dst) ; src++, dst++) i++;
 	i /= 2;
 	return (i > MaxYomiAskNumber) ? MaxYomiAskNumber : i;
@@ -181,11 +181,11 @@ top_strcmp (Uchar *src, Uchar *dst)
 
 
 
-static	Int
-last_strcmp (Uchar *src, Uchar *dst)
+static	int
+last_strcmp (u_char *src, u_char *dst)
 {
-	Int	slen;
-	Int	dlen;
+	int	slen;
+	int	dlen;
 
 	slen = strlen(src);
 	dlen = strlen(dst);
@@ -199,21 +199,21 @@ last_strcmp (Uchar *src, Uchar *dst)
 
 
 
-Int
-cvtknj (Uchar *yomi, Uchar *knj, Uchar *dst)
+int
+cvtknj (u_char *yomi, u_char *knj, u_char *dst)
 {
-	Uchar	kana[MaxWdYomiLen * 2 + 1];
-	Int	len;
-	Uchar	*keep;
+	u_char	kana[MaxWdYomiLen * 2 + 1];
+	int	len;
+	u_char	*keep;
 
 	keep = dst;			
 	yomi2kata(yomi, kana);		
 
 	if ((len = top_strcmp(yomi, knj)) != 0) {
-                *dst = (Uchar)(ZenHiraAssyuku | (len - 1));
+                *dst = (u_char)(ZenHiraAssyuku | (len - 1));
 	}
 	else if ((len = top_strcmp(kana, knj)) != 0) {
-                *dst = (Uchar)(ZenKataAssyuku | (len - 1));
+                *dst = (u_char)(ZenKataAssyuku | (len - 1));
 	}
 
 	if (len) {
@@ -224,16 +224,16 @@ cvtknj (Uchar *yomi, Uchar *knj, Uchar *dst)
 	if (*knj) {
 		for ( ; ; ) {
 			if ((len = last_strcmp(yomi, knj)) != 0) {
-				*dst++ = (Uchar)(ZenHiraAssyuku | (len - 1));
+				*dst++ = (u_char)(ZenHiraAssyuku | (len - 1));
 				break;
 			}
 			else if ((len = last_strcmp(kana, knj)) != 0) {
-				*dst++ = (Uchar)(ZenKataAssyuku | (len - 1));
+				*dst++ = (u_char)(ZenKataAssyuku | (len - 1));
 				break;
 			}
 			else if (*knj == SS2) {
 				knj++;
-				*dst++ = (Uchar)LeadingHankaku;
+				*dst++ = (u_char)LeadingHankaku;
 				*dst++ = *knj++;
 			} else if (*knj == SS3) {
 				knj++;
@@ -244,7 +244,7 @@ cvtknj (Uchar *yomi, Uchar *knj, Uchar *dst)
 				*dst++ = (*knj & NormalKanjiMask); knj++;
 			}
 			else {
-				*dst++ = (Uchar)LeadingHankaku;
+				*dst++ = (u_char)LeadingHankaku;
 				*dst++ = *knj++;
 			}
 
@@ -261,14 +261,14 @@ cvtknj (Uchar *yomi, Uchar *knj, Uchar *dst)
 
 
 
-Int
-srchkana (Uchar **ptr, Int *saml)	
+int
+srchkana (u_char **ptr, int *saml)
 {
-	Uchar	*p;
-	Int	cmp;
-	Int	cnt = 0;
-	Uchar	same;
-	Int	flg = 0;
+	u_char	*p;
+	int	cmp;
+	int	cnt = 0;
+	u_char	same;
+	int	flg = 0;
 
 	same = 0;
 
@@ -301,12 +301,12 @@ srchkana (Uchar **ptr, Int *saml)
 
 
 
-Int
-srchgram (Uchar *ptr, Uchar **dst, TypeGram hinsi)
+int
+srchgram (u_char *ptr, u_char **dst, TypeGram hinsi)
 {
-	Uchar	*endp;
-	Int	cnt = 0, nlen;
-	Int	flg = FALSE;
+	u_char	*endp;
+	int	cnt = 0, nlen;
+	int	flg = FALSE;
 
 	endp = getntag(ptr);
 
@@ -333,14 +333,14 @@ srchgram (Uchar *ptr, Uchar **dst, TypeGram hinsi)
 
 
 
-Int
-srchkanji (Uchar **dst, Uchar *knj, Int klen)
+int
+srchkanji (u_char **dst, u_char *knj, int klen)
 {
-	Uchar	*ptr;
-	Uchar	*p, *q;
-	Int	len;
-	Int	flg = FALSE;
-	Int	cnt = 0;
+	u_char	*ptr;
+	u_char	*p, *q;
+	int	len;
+	int	flg = FALSE;
+	int	cnt = 0;
 
 	ptr = *dst + 1;
 
@@ -370,7 +370,7 @@ srchkanji (Uchar **dst, Uchar *knj, Int klen)
 TypeIdxOfs
 count_uidx (void)
 {
-	Uchar	*p;
+	u_char	*p;
 
 	p = get_idxptr(curdict->segunit - 1);
 	while (*p++) ;
@@ -381,10 +381,10 @@ count_uidx (void)
 
 
 void
-chg_uidx (TypeDicSeg seg, Uchar *yomi, Int len)
+chg_uidx (TypeDicSeg seg, u_char *yomi, int len)
 {
-	Uchar		*p, *q;
-	Int		olen;
+	u_char		*p, *q;
+	int		olen;
 
 	p = get_idxptr(seg);
 
@@ -393,10 +393,10 @@ chg_uidx (TypeDicSeg seg, Uchar *yomi, Int len)
 	q = idxbuf + curdict->idxlen;
 
 	if (len > olen) {
-		mvmemd(q - (len-olen), q, (Int)(q - (len-olen) - p));
+		mvmemd(q - (len-olen), q, (int)(q - (len-olen) - p));
 	}
 	else {
-		mvmemi(p + (olen-len), p, (Int)(q - (p + (olen-len))));
+		mvmemi(p + (olen-len), p, (int)(q - (p + (olen-len))));
 	}
 
 	while (len--) *p++ = *yomi++;

--- a/chrtbl.c
+++ b/chrtbl.c
@@ -42,7 +42,7 @@
 
 
 
-Uchar	chrtbl[256] =		
+u_char	chrtbl[256] =
 {
 	0,				
 	FZKTOP,				

--- a/cl2knj.c
+++ b/cl2knj.c
@@ -41,7 +41,7 @@
 #include "kanakan.h"
 
 
-Int	sj2cd_chr();
+int	sj2cd_chr();
 void	cvtclknj(), freework();
 
 

--- a/clstudy.c
+++ b/clstudy.c
@@ -68,7 +68,7 @@ clstudy(u_char* yomi1, u_char* yomi2, STDYOUT *stdy)
 		if (!sj2cd_str(yomi1, ytmp, CLSTDY_TMPLEN))
 			return ClstudyYomiErr;
 
-		(Void)delcldata(ytmp);
+		(void)delcldata(ytmp);
 
 		ret = ClstudyNormEnd;
 	}
@@ -101,9 +101,9 @@ clstudy(u_char* yomi1, u_char* yomi2, STDYOUT *stdy)
 
 			ptr = ClStudyTail - alen;
 			mvmemd(ptr, ClStudyTail, (ptr - dst));
-			ClYomiLen(dst)  = (Uchar)len2;
+			ClYomiLen(dst)  = (u_char)len2;
 			ClGramCode(dst) = stdy -> hinshi;
-			ClYomi1Len(dst) = (Uchar)len1;
+			ClYomi1Len(dst) = (u_char)len1;
 			ClSetNum(dst, 1);
 			memcpy(ytmp, ClYomiPos(dst), len2);
 
@@ -278,9 +278,9 @@ mkclidx(void)
 			ptr = ClNextTag(ptr);
 		}
 
-		if (ClYomiLen(ptr) && ((Int)*ClYomiPos(ptr) < ed))
+		if (ClYomiLen(ptr) && ((int)*ClYomiPos(ptr) < ed))
 			ClStudyIdx[num] = ptr - ClStudyDict;
 		else
-			ClStudyIdx[num] = (Ushort)-1;
+			ClStudyIdx[num] = (u_short)-1;
 	}
 }

--- a/cmpstr.c
+++ b/cmpstr.c
@@ -41,9 +41,9 @@
 #include "const.h"
 #include "sj_typedef.h"
 
-Int	cmpstr(src, dst)
-Uchar	*src;
-Uchar	*dst;
+int	cmpstr(src, dst)
+u_char	*src;
+u_char	*dst;
 {
 	while (*src) {
 		if (*src != *dst) return FALSE;

--- a/conjunc.c
+++ b/conjunc.c
@@ -39,7 +39,7 @@
 #include "sj_yomi.h"
 #include "sj_right.h"
 
-static	Uchar	sahencnj[] = {
+static	u_char	sahencnj[] = {
 		0x00,				R_SGOKAN,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -63,7 +63,7 @@ static	Uchar	sahencnj[] = {
 		0xff
 	};
 
-static	Uchar	zahencnj[] = {
+static	u_char	zahencnj[] = {
 		0x00,				R_CUT,		
 		0x01,	_ZI,			R_JI,		
 		0x11,	_YO,			R_MEIREI2,	
@@ -77,7 +77,7 @@ static	Uchar	zahencnj[] = {
 		0xff
 	};
 
-static	Uchar	ka5cnj1[] = {
+static	u_char	ka5cnj1[] = {
 		0x01,	_I,			R_ONBIN2,	
 		0x01,	_KA,			R_MIZEN5,	
 		0x01,	_KI,			R_RENYOU5,	
@@ -87,7 +87,7 @@ static	Uchar	ka5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ka5cnj3[] = {
+static	u_char	ka5cnj3[] = {
 		0x01,	_I,			R_ONBIN2,	
 		0x01,	_KA,			R_MIZEN5,	
 		0x01,	_KI,			R_RENYOU7,	
@@ -97,7 +97,7 @@ static	Uchar	ka5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ka5cnj5[] = {
+static	u_char	ka5cnj5[] = {
 		0x01,	_I,			R_ONBIN2,	
 		0x01,	_KA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -113,7 +113,7 @@ static	Uchar	ka5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ka5cnj7[] = {
+static	u_char	ka5cnj7[] = {
 		0x01,	_I,			R_ONBIN2,	
 		0x01,	_KA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -129,7 +129,7 @@ static	Uchar	ka5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	ga5cnj1[] = {
+static	u_char	ga5cnj1[] = {
 		0x01,	_I,			R_ONBIN3,	
 		0x01,	_GA,			R_MIZEN5,	
 		0x01,	_GI,			R_RENYOU5,	
@@ -139,7 +139,7 @@ static	Uchar	ga5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ga5cnj3[] = {
+static	u_char	ga5cnj3[] = {
 		0x01,	_I,			R_ONBIN3,	
 		0x01,	_GA,			R_MIZEN5,	
 		0x01,	_GI,			R_RENYOU7,	
@@ -149,7 +149,7 @@ static	Uchar	ga5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ga5cnj5[] = {
+static	u_char	ga5cnj5[] = {
 		0x01,	_I,			R_ONBIN3,	
 		0x01,	_GA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -165,7 +165,7 @@ static	Uchar	ga5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ga5cnj7[] = {
+static	u_char	ga5cnj7[] = {
 		0x01,	_I,			R_ONBIN3,	
 		0x01,	_GA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -181,7 +181,7 @@ static	Uchar	ga5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	sa5cnj1[] = {
+static	u_char	sa5cnj1[] = {
 		0x01,	_SA,			R_MIZEN5,	
 		0x01,	_SI,			R_SA5RENYOU1,	
 		0x01,	_SU,			R_SHUUSI,	
@@ -190,7 +190,7 @@ static	Uchar	sa5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	sa5cnj3[] = {
+static	u_char	sa5cnj3[] = {
 		0x01,	_SA,			R_MIZEN5,	
 		0x01,	_SI,			R_SA5RENYOU3,	
 		0x01,	_SU,			R_SHUUSI,	
@@ -199,7 +199,7 @@ static	Uchar	sa5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	sa5cnj5[] = {
+static	u_char	sa5cnj5[] = {
 		0x01,	_SA,			R_MIZEN5,	
 		0x01,	_SI,			R_SA5RENYOU1,	
 		0x01,	_SU,			R_SHUUSI,	
@@ -210,7 +210,7 @@ static	Uchar	sa5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	sa5cnj7[] = {
+static	u_char	sa5cnj7[] = {
 		0x01,	_SA,			R_MIZEN5,	
 		0x01,	_SI,			R_SA5RENYOU3,	
 		0x01,	_SU,			R_SHUUSI,	
@@ -221,7 +221,7 @@ static	Uchar	sa5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	ta5cnj1[] = {
+static	u_char	ta5cnj1[] = {
 		0x01,	_TA,			R_MIZEN5,	
 		0x01,	_TI,			R_RENYOU5,	
 		0x01,	_XTU,			R_ONBIN2,	
@@ -231,7 +231,7 @@ static	Uchar	ta5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ta5cnj3[] = {
+static	u_char	ta5cnj3[] = {
 		0x01,	_TA,			R_MIZEN5,	
 		0x01,	_TI,			R_RENYOU7,	
 		0x01,	_XTU,			R_ONBIN2,	
@@ -241,7 +241,7 @@ static	Uchar	ta5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ta5cnj5[] = {
+static	u_char	ta5cnj5[] = {
 		0x01,	_TA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -257,7 +257,7 @@ static	Uchar	ta5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ta5cnj7[] = {
+static	u_char	ta5cnj7[] = {
 		0x01,	_TA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -274,7 +274,7 @@ static	Uchar	ta5cnj7[] = {
 	};
 		
 
-static	Uchar	na5cnj[] = {
+static	u_char	na5cnj[] = {
 		0x01,	_NA,			R_MIZEN5,	
 		0x01,	_NI,			R_RENYOU5,	
 		0x01,	_NU,			R_SHUUSI,	
@@ -284,7 +284,7 @@ static	Uchar	na5cnj[] = {
 		0xff
 	};
 
-static	Uchar	ba5cnj1[] = {
+static	u_char	ba5cnj1[] = {
 		0x01,	_BA,			R_MIZEN5,	
 		0x01,	_BI,			R_RENYOU5,	
 		0x01,	_BU,			R_SHUUSI,	
@@ -294,7 +294,7 @@ static	Uchar	ba5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ba5cnj3[] = {
+static	u_char	ba5cnj3[] = {
 		0x01,	_BA,			R_MIZEN5,	
 		0x01,	_BI,			R_RENYOU7,	
 		0x01,	_BU,			R_SHUUSI,	
@@ -304,7 +304,7 @@ static	Uchar	ba5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ba5cnj5[] = {
+static	u_char	ba5cnj5[] = {
 		0x01,	_BA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -320,7 +320,7 @@ static	Uchar	ba5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ba5cnj7[] = {
+static	u_char	ba5cnj7[] = {
 		0x01,	_BA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -336,7 +336,7 @@ static	Uchar	ba5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	ma5cnj1[] = {
+static	u_char	ma5cnj1[] = {
 		0x01,	_MA,			R_MIZEN5,	
 		0x01,	_MI,			R_RENYOU5,	
 		0x01,	_MU,			R_SHUUSI,	
@@ -346,7 +346,7 @@ static	Uchar	ma5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ma5cnj3[] = {
+static	u_char	ma5cnj3[] = {
 		0x01,	_MA,			R_MIZEN5,	
 		0x01,	_MI,			R_RENYOU7,	
 		0x01,	_MU,			R_SHUUSI,	
@@ -356,7 +356,7 @@ static	Uchar	ma5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ma5cnj5[] = {
+static	u_char	ma5cnj5[] = {
 		0x01,	_MA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -372,7 +372,7 @@ static	Uchar	ma5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ma5cnj7[] = {
+static	u_char	ma5cnj7[] = {
 		0x01,	_MA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
 		0x11,	_SI,			R_SA5RENYOU3,	
@@ -388,7 +388,7 @@ static	Uchar	ma5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	ra5cnj1[] = {
+static	u_char	ra5cnj1[] = {
 		0x01,	_XTU,			R_ONBIN2,	
 		0x01,	_RA,			R_MIZEN5,	
 		0x01,	_RI,			R_RENYOU5,	
@@ -398,7 +398,7 @@ static	Uchar	ra5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	ra5cnj3[] = {
+static	u_char	ra5cnj3[] = {
 		0x01,	_XTU,			R_ONBIN2,	
 		0x01,	_RA,			R_MIZEN5,	
 		0x01,	_RI,			R_RENYOU7,	
@@ -408,7 +408,7 @@ static	Uchar	ra5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	ra5cnj5[] = {
+static	u_char	ra5cnj5[] = {
 		0x01,	_XTU,			R_ONBIN2,	
 		0x01,	_RA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -424,7 +424,7 @@ static	Uchar	ra5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	ra5cnj7[] = {
+static	u_char	ra5cnj7[] = {
 		0x01,	_XTU,			R_ONBIN2,	
 		0x01,	_RA,			R_MIZEN5,	
 		0x11,	_SA,			R_MIZEN5,	
@@ -440,7 +440,7 @@ static	Uchar	ra5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	wa5cnj1[] = {
+static	u_char	wa5cnj1[] = {
 		0x01,	_I,			R_RENYOU5,	
 		0x01,	_U,			R_SHUUSI,	
 		0x01,	_E,			R_KAMEI,	
@@ -450,7 +450,7 @@ static	Uchar	wa5cnj1[] = {
 		0xff
 	};
 
-static	Uchar	wa5cnj3[] = {
+static	u_char	wa5cnj3[] = {
 		0x01,	_I,			R_RENYOU7,	
 		0x01,	_U,			R_SHUUSI,	
 		0x01,	_E,			R_KAMEI,	
@@ -460,7 +460,7 @@ static	Uchar	wa5cnj3[] = {
 		0xff
 	};
 
-static	Uchar	wa5cnj5[] = {
+static	u_char	wa5cnj5[] = {
 		0x01,	_I,			R_RENYOU5,	
 		0x01,	_U,			R_SHUUSI,	
 		0x01,	_E,			R_EXP,		
@@ -476,7 +476,7 @@ static	Uchar	wa5cnj5[] = {
 		0xff
 	};
 
-static	Uchar	wa5cnj7[] = {
+static	u_char	wa5cnj7[] = {
 		0x01,	_I,			R_RENYOU7,	
 		0x01,	_U,			R_SHUUSI,	
 		0x01,	_E,			R_EXP,		
@@ -492,7 +492,7 @@ static	Uchar	wa5cnj7[] = {
 		0xff
 	};
 
-static	Uchar	ichicnj1[] = {
+static	u_char	ichicnj1[] = {
 		0x00,				R_RENYOU1,	
 		0x01,	_YO,			R_MEIREI2,	
 		0x01,	_RU,			R_SHUUSI,	
@@ -501,7 +501,7 @@ static	Uchar	ichicnj1[] = {
 		0xff
 	};
 
-static	Uchar	ichicnj3[] = {
+static	u_char	ichicnj3[] = {
 		0x00,				R_RENYOU3,	
 		0x01,	_YO,			R_MEIREI2,	
 		0x01,	_RU,			R_SHUUSI,	
@@ -510,7 +510,7 @@ static	Uchar	ichicnj3[] = {
 		0xff
 	};
 
-static	Uchar	keiyou1[] = {
+static	u_char	keiyou1[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -521,7 +521,7 @@ static	Uchar	keiyou1[] = {
 		0xff
 	};
 
-static	Uchar	keiyou2[] = {
+static	u_char	keiyou2[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -533,7 +533,7 @@ static	Uchar	keiyou2[] = {
 		0xff
 	};
 
-static	Uchar	keiyou3[] = {
+static	u_char	keiyou3[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -556,7 +556,7 @@ static	Uchar	keiyou3[] = {
 		0xff
 	};
 
-static	Uchar	keiyou4[] = {
+static	u_char	keiyou4[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -574,7 +574,7 @@ static	Uchar	keiyou4[] = {
 		0xff
 	};
 
-static	Uchar	keiyou5[] = {
+static	u_char	keiyou5[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -603,7 +603,7 @@ static	Uchar	keiyou5[] = {
 		0xff
 	};
 
-static	Uchar	keiyou6[] = {
+static	u_char	keiyou6[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -637,7 +637,7 @@ static	Uchar	keiyou6[] = {
 		0xff
 	};
 
-static	Uchar	keiyou7[] = {
+static	u_char	keiyou7[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -677,7 +677,7 @@ static	Uchar	keiyou7[] = {
 		0xff
 	};
 
-static	Uchar	keiyou8[] = {
+static	u_char	keiyou8[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -718,7 +718,7 @@ static	Uchar	keiyou8[] = {
 		0xff
 	};
 
-static	Uchar	keiyou9[] = {
+static	u_char	keiyou9[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -747,7 +747,7 @@ static	Uchar	keiyou9[] = {
 		0xff
 	};
 
-static	Uchar	keiyou10[] = {
+static	u_char	keiyou10[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -787,7 +787,7 @@ static	Uchar	keiyou10[] = {
 		0xff
 	};
 
-static	Uchar	keiyou11[] = {
+static	u_char	keiyou11[] = {
 		0x80,				R_KGOKAN,	
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -811,7 +811,7 @@ static	Uchar	keiyou11[] = {
 		0xff
 	};
 
-static	Uchar	keidou1[] = {
+static	u_char	keidou1[] = {
 		0x80,				R_DGOKAN,	
 		0x01,	_DA,			R_DSHUUSI1,	
 		0x11,	_XTU,			R_ONBIN1,	
@@ -826,7 +826,7 @@ static	Uchar	keidou1[] = {
 		0xff
 	};
 
-static	Uchar	keidou2[] = {
+static	u_char	keidou2[] = {
 		0x80,				R_DGOKAN,	
 		0x02,	_TA, _RU,		R_DRENTAI2,	
 		0x11,	_RE,			R_KATEI2,	
@@ -834,7 +834,7 @@ static	Uchar	keidou2[] = {
 		0xff
 	};
 
-static	Uchar	keidou4[] = {
+static	u_char	keidou4[] = {
 		0x80,				R_DGOKAN,	
 		0x01,	_SA,			R_FZKMEISI,	
 		0x01,	_DA,			R_DSHUUSI1,	
@@ -850,7 +850,7 @@ static	Uchar	keidou4[] = {
 		0xff
 	};
 
-static	Uchar	keidou9[] = {
+static	u_char	keidou9[] = {
 		0x80,				R_DGOKAN,	
 		0x01,	_DA,			R_DSHUUSI1,	
 		0x11,	_XTU,			R_ONBIN1,	
@@ -867,7 +867,7 @@ static	Uchar	keidou9[] = {
 		0xff
 	};
 
-static	Uchar	sahenmeisi1[] = {
+static	u_char	sahenmeisi1[] = {
 		0x00,				R_SMEISI1,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -880,7 +880,7 @@ static	Uchar	sahenmeisi1[] = {
 		0xff
 	};
 
-static	Uchar	sahenmeisi2[] = {
+static	u_char	sahenmeisi2[] = {
 		0x00,				R_SMEISI1,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -893,7 +893,7 @@ static	Uchar	sahenmeisi2[] = {
 		0xff
 	};
 
-static	Uchar	keidoumeisi[] = {
+static	u_char	keidoumeisi[] = {
 		0x00,				R_DMEISI,	
 		0x01,	_SA,			R_FZKMEISI,	
 		0x01,	_DA,			R_DSHUUSI1,	
@@ -909,7 +909,7 @@ static	Uchar	keidoumeisi[] = {
 		0xff
 	};
 
-static	Uchar	keiyoustb[] = {
+static	u_char	keiyoustb[] = {
 		0x00,				R_KSTB,		
 		0x01,	_I,			R_KSHUUSI,	
 		0x02,	_KA, _XTU,		R_ONBIN1,	
@@ -920,7 +920,7 @@ static	Uchar	keiyoustb[] = {
 		0xff
 	};
 
-static	Uchar	ichistb[] = {
+static	u_char	ichistb[] = {
 		0x00,				R_ICHISETUBI,	
 		0x01,	_YO,			R_MEIREI2,	
 		0x01,	_RU,			R_SHUUSI,	
@@ -929,7 +929,7 @@ static	Uchar	ichistb[] = {
 		0xff
 	};
 
-static	Uchar	fukusi2[] = {
+static	u_char	fukusi2[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_TO,			R_F_FUKUSI,	
 		0x11,	_SI,			R_SI1,		
@@ -937,7 +937,7 @@ static	Uchar	fukusi2[] = {
 		0xff
 	};
 
-static	Uchar	fukusi3[] = {
+static	u_char	fukusi3[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -953,7 +953,7 @@ static	Uchar	fukusi3[] = {
 		0xff
 	};
 
-static	Uchar	fukusi4[] = {
+static	u_char	fukusi4[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -966,25 +966,25 @@ static	Uchar	fukusi4[] = {
 		0xff
 	};
 
-static	Uchar	fukusi5[] = {
+static	u_char	fukusi5[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_NI,			R_F_FUKUSI,	
 		0xff
 	};
 
-static	Uchar	fukusi6[] = {
+static	u_char	fukusi6[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_MO,			R_F_FUKUSI,	
 		0xff
 	};
 
-static	Uchar	fukusi7[] = {
+static	u_char	fukusi7[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_NO,			R_F_FUKUSI,	
 		0xff
 	};
 
-static	Uchar	fukusi8[] = {
+static	u_char	fukusi8[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_DA,			R_DSHUUSI1,	
 		0x11,	_XTU,			R_ONBIN1,	
@@ -998,7 +998,7 @@ static	Uchar	fukusi8[] = {
 		0xff
 	};
 
-static	Uchar	fukusi9[] = {
+static	u_char	fukusi9[] = {
 		0x00,				R_FUKUSI,	
 		0x01,	_SA,			R_MIZEN1,	
 		0x01,	_SI,			R_SI1,		
@@ -1021,7 +1021,7 @@ static	Uchar	fukusi9[] = {
 		0xff
 	};
 
-Uchar	*conjadr[] = {
+u_char	*conjadr[] = {
 		0,			
 		0,			
 		0,			

--- a/connect.c
+++ b/connect.c
@@ -40,7 +40,7 @@
 #include "sj_connect.h"
 #include "sj_right.h"
 
-static	Uchar	mizen1[] = {
+static	u_char	mizen1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -72,7 +72,7 @@ static	Uchar	mizen1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	mizen2[] = {
+static	u_char	mizen2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -104,7 +104,7 @@ static	Uchar	mizen2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mizen3[] = {
+static	u_char	mizen3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -136,7 +136,7 @@ static	Uchar	mizen3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mizen4[] = {
+static	u_char	mizen4[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -168,7 +168,7 @@ static	Uchar	mizen4[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mizen5[] = {
+static	u_char	mizen5[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -200,7 +200,7 @@ static	Uchar	mizen5[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	arou[] = {
+static	u_char	arou[] = {
 		wo_x+ttatte_o +ttara_o +tte1_o +tte2_x +ppanasi_x +ppoi_x +ue_x,
 		uti_x +oite_x +okeru_x +ori_x +ka1_x +ka2_o +kai_x +kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -232,7 +232,7 @@ static	Uchar	arou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	you1[] = {
+static	u_char	you1[] = {
 		wo_x+ttatte_o +ttara_o +tte1_o +tte2_x +ppanasi_x +ppoi_x +ue_x,
 		uti_x +oite_x +okeru_x +ori_x +ka1_x +ka2_o +kai_x +kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -264,7 +264,7 @@ static	Uchar	you1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	karou[] = {	
+static	u_char	karou[] = {
 		wo_x+ttatte_o +ttara_x +tte1_o +tte2_x +ppanasi_x +ppoi_x +ue_x,
 		uti_x +oite_x +okeru_x +ori_x +ka1_x +ka2_o +kai_x +kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -297,7 +297,7 @@ static	Uchar	karou[] = {
 	};
 		
 
-static	Uchar	darou[] = {
+static	u_char	darou[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_o+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -329,7 +329,7 @@ static	Uchar	darou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	deshou[] = {
+static	u_char	deshou[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -361,7 +361,7 @@ static	Uchar	deshou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ko[] = {
+static	u_char	ko[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -393,7 +393,7 @@ static	Uchar	ko[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	bekara[] = {
+static	u_char	bekara[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -425,7 +425,7 @@ static	Uchar	bekara[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tagara[] = {
+static	u_char	tagara[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -457,7 +457,7 @@ static	Uchar	tagara[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	si1[] = {
+static	u_char	si1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -489,7 +489,7 @@ static	Uchar	si1[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ji[] = {
+static	u_char	ji[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -521,7 +521,7 @@ static	Uchar	ji[] = {
 		yasui_o+yoi_o+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	age[] = {
+static	u_char	age[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -553,7 +553,7 @@ static	Uchar	age[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	i[] = {
+static	u_char	i[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -585,7 +585,7 @@ static	Uchar	i[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	e[] = {
+static	u_char	e[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -617,7 +617,7 @@ static	Uchar	e[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kake[] = {
+static	u_char	kake[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -649,7 +649,7 @@ static	Uchar	kake[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kane2[] = {
+static	u_char	kane2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -681,7 +681,7 @@ static	Uchar	kane2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sugi[] = {
+static	u_char	sugi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -713,7 +713,7 @@ static	Uchar	sugi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	deki[] = {
+static	u_char	deki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -745,7 +745,7 @@ static	Uchar	deki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mi[] = {
+static	u_char	mi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -777,7 +777,7 @@ static	Uchar	mi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sase[] = {
+static	u_char	sase[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -809,7 +809,7 @@ static	Uchar	sase[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	rare[] = {
+static	u_char	rare[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -841,7 +841,7 @@ static	Uchar	rare[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	itadake[] = {
+static	u_char	itadake[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -873,7 +873,7 @@ static	Uchar	itadake[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	exp[] = {
+static	u_char	exp[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -905,7 +905,7 @@ static	Uchar	exp[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou1[] = {
+static	u_char	renyou1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -937,7 +937,7 @@ static	Uchar	renyou1[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou3[] = {
+static	u_char	renyou3[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -969,7 +969,7 @@ static	Uchar	renyou3[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou4[] = {
+static	u_char	renyou4[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -1001,7 +1001,7 @@ static	Uchar	renyou4[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou5[] = {
+static	u_char	renyou5[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1033,7 +1033,7 @@ static	Uchar	renyou5[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou7[] = {
+static	u_char	renyou7[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -1065,7 +1065,7 @@ static	Uchar	renyou7[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	renyou8[] = {
+static	u_char	renyou8[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -1097,7 +1097,7 @@ static	Uchar	renyou8[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sa5renyou1[] = {
+static	u_char	sa5renyou1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1129,7 +1129,7 @@ static	Uchar	sa5renyou1[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sa5renyou3[] = {
+static	u_char	sa5renyou3[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -1161,7 +1161,7 @@ static	Uchar	sa5renyou3[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sa5renyou4[] = {
+static	u_char	sa5renyou4[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -1193,7 +1193,7 @@ static	Uchar	sa5renyou4[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	krenyou[] = {
+static	u_char	krenyou[] = {
 		wo_x+ttatte_o+ttara_x+tte1_x+tte2_o+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1225,7 +1225,7 @@ static	Uchar	krenyou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drenyou1[] = {
+static	u_char	drenyou1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1257,7 +1257,7 @@ static	Uchar	drenyou1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drenyou2[] = {
+static	u_char	drenyou2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_o+okeru_o+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1289,7 +1289,7 @@ static	Uchar	drenyou2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drenyou3[] = {
+static	u_char	drenyou3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1321,7 +1321,7 @@ static	Uchar	drenyou3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	onbin1[] = {
+static	u_char	onbin1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1354,7 +1354,7 @@ static	Uchar	onbin1[] = {
 	};
 		
 
-static	Uchar	onbin2[] = {
+static	u_char	onbin2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1386,7 +1386,7 @@ static	Uchar	onbin2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	onbin3[] = {
+static	u_char	onbin3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1418,7 +1418,7 @@ static	Uchar	onbin3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	deshi[] = {
+static	u_char	deshi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1450,7 +1450,7 @@ static	Uchar	deshi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	axtu[] = {
+static	u_char	axtu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1482,7 +1482,7 @@ static	Uchar	axtu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	onbin6[] = {
+static	u_char	onbin6[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1514,7 +1514,7 @@ static	Uchar	onbin6[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	onbin8[] = {
+static	u_char	onbin8[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1546,7 +1546,7 @@ static	Uchar	onbin8[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ari1[] = {
+static	u_char	ari1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1578,7 +1578,7 @@ static	Uchar	ari1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ari2[] = {
+static	u_char	ari2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1610,7 +1610,7 @@ static	Uchar	ari2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ari3[] = {
+static	u_char	ari3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1642,7 +1642,7 @@ static	Uchar	ari3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	iki[] = {
+static	u_char	iki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1674,7 +1674,7 @@ static	Uchar	iki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	itasi[] = {
+static	u_char	itasi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1706,7 +1706,7 @@ static	Uchar	itasi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	itadaki[] = {
+static	u_char	itadaki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1738,7 +1738,7 @@ static	Uchar	itadaki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ori2[] = {
+static	u_char	ori2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1770,7 +1770,7 @@ static	Uchar	ori2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	gataku[] = {
+static	u_char	gataku[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_o+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1802,7 +1802,7 @@ static	Uchar	gataku[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ki[] = {
+static	u_char	ki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1834,7 +1834,7 @@ static	Uchar	ki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	fzkki[] = {
+static	u_char	fzkki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1866,7 +1866,7 @@ static	Uchar	fzkki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	deha[] = {
+static	u_char	deha[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1898,7 +1898,7 @@ static	Uchar	deha[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	kudasai[] = {
+static	u_char	kudasai[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1930,7 +1930,7 @@ static	Uchar	kudasai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gozai[] = {
+static	u_char	gozai[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1962,7 +1962,7 @@ static	Uchar	gozai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gotoku[] = {
+static	u_char	gotoku[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -1994,7 +1994,7 @@ static	Uchar	gotoku[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	beku[] = {	
+static	u_char	beku[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2026,7 +2026,7 @@ static	Uchar	beku[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	soude[] = {
+static	u_char	soude[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2058,7 +2058,7 @@ static	Uchar	soude[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	souni[] = {
+static	u_char	souni[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2090,7 +2090,7 @@ static	Uchar	souni[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tagari[] = {
+static	u_char	tagari[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2122,7 +2122,7 @@ static	Uchar	tagari[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	taku[] = {
+static	u_char	taku[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_o+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2154,7 +2154,7 @@ static	Uchar	taku[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	de[] = {
+static	u_char	de[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2186,7 +2186,7 @@ static	Uchar	de[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	naide[] = {
+static	u_char	naide[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2218,7 +2218,7 @@ static	Uchar	naide[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	naku[] = {
+static	u_char	naku[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_o+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2250,7 +2250,7 @@ static	Uchar	naku[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nasai[] = {
+static	u_char	nasai[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2282,7 +2282,7 @@ static	Uchar	nasai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	fuuni[] = {
+static	u_char	fuuni[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2314,7 +2314,7 @@ static	Uchar	fuuni[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	yori2[] = {
+static	u_char	yori2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2346,7 +2346,7 @@ static	Uchar	yori2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	rashuu[] = {
+static	u_char	rashuu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2378,7 +2378,7 @@ static	Uchar	rashuu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dshuusi1[] = {
+static	u_char	dshuusi1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_o+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2410,7 +2410,7 @@ static	Uchar	dshuusi1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dshuusi2[] = {
+static	u_char	dshuusi2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2442,7 +2442,7 @@ static	Uchar	dshuusi2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gotosi[] = {
+static	u_char	gotosi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2474,7 +2474,7 @@ static	Uchar	gotosi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	besi[] = {
+static	u_char	besi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2506,7 +2506,7 @@ static	Uchar	besi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	zu[] = {
+static	u_char	zu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2538,7 +2538,7 @@ static	Uchar	zu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	souda[] = {
+static	u_char	souda[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_o+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2570,7 +2570,7 @@ static	Uchar	souda[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mai[] = {
+static	u_char	mai[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2602,7 +2602,7 @@ static	Uchar	mai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mitaida[] = {
+static	u_char	mitaida[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2634,7 +2634,7 @@ static	Uchar	mitaida[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	shuusi[] = {
+static	u_char	shuusi[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_o+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2666,7 +2666,7 @@ static	Uchar	shuusi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kshuusi[] = {
+static	u_char	kshuusi[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2698,7 +2698,7 @@ static	Uchar	kshuusi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	zaru[] = {
+static	u_char	zaru[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_o+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -2730,7 +2730,7 @@ static	Uchar	zaru[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	soudesu[] = {
+static	u_char	soudesu[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2762,7 +2762,7 @@ static	Uchar	soudesu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ta[] = {
+static	u_char	ta[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_o+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2794,7 +2794,7 @@ static	Uchar	ta[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tai[] = {
+static	u_char	tai[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2826,7 +2826,7 @@ static	Uchar	tai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	desu[] = {
+static	u_char	desu[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2858,7 +2858,7 @@ static	Uchar	desu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nai[] = {
+static	u_char	nai[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2890,7 +2890,7 @@ static	Uchar	nai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nu[] = {
+static	u_char	nu[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_o+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2922,7 +2922,7 @@ static	Uchar	nu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	masu[] = {
+static	u_char	masu[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_o+ka1_x+ka2_o+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -2954,7 +2954,7 @@ static	Uchar	masu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nn2[] = {
+static	u_char	nn2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -2986,7 +2986,7 @@ static	Uchar	nn2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	rasii[] = {
+static	u_char	rasii[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -3018,7 +3018,7 @@ static	Uchar	rasii[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drentai1[] = {
+static	u_char	drentai1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3050,7 +3050,7 @@ static	Uchar	drentai1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drentai2[] = {
+static	u_char	drentai2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3082,7 +3082,7 @@ static	Uchar	drentai2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	drentai3[] = {
+static	u_char	drentai3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3114,7 +3114,7 @@ static	Uchar	drentai3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	krentai[] = {
+static	u_char	krentai[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3146,7 +3146,7 @@ static	Uchar	krentai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gotoki[] = {
+static	u_char	gotoki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3178,7 +3178,7 @@ static	Uchar	gotoki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	beki[] = {
+static	u_char	beki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -3210,7 +3210,7 @@ static	Uchar	beki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	souna1[] = {
+static	u_char	souna1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3242,7 +3242,7 @@ static	Uchar	souna1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	souna2[] = {
+static	u_char	souna2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3274,7 +3274,7 @@ static	Uchar	souna2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	na2[] = {
+static	u_char	na2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3306,7 +3306,7 @@ static	Uchar	na2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	katei1[] = {
+static	u_char	katei1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3338,7 +3338,7 @@ static	Uchar	katei1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	katei2[] = {
+static	u_char	katei2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3370,7 +3370,7 @@ static	Uchar	katei2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	katei3[] = {
+static	u_char	katei3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3402,7 +3402,7 @@ static	Uchar	katei3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kamei[] = {
+static	u_char	kamei[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3434,7 +3434,7 @@ static	Uchar	kamei[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ike[] = {
+static	u_char	ike[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3466,7 +3466,7 @@ static	Uchar	ike[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kure[] = {
+static	u_char	kure[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3498,7 +3498,7 @@ static	Uchar	kure[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	meirei1[] = {
+static	u_char	meirei1[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3530,7 +3530,7 @@ static	Uchar	meirei1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	meirei2[] = {
+static	u_char	meirei2[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3562,7 +3562,7 @@ static	Uchar	meirei2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dgokan[] = {
+static	u_char	dgokan[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -3594,7 +3594,7 @@ static	Uchar	dgokan[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_o
 	};
 		
-static	Uchar	kgokan[] = {
+static	u_char	kgokan[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3626,7 +3626,7 @@ static	Uchar	kgokan[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_o
 	};
 		
-static	Uchar	sgokan[] = {
+static	u_char	sgokan[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3658,7 +3658,7 @@ static	Uchar	sgokan[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gati[] = {
+static	u_char	gati[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -3690,7 +3690,7 @@ static	Uchar	gati[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	jya[] = {
+static	u_char	jya[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3722,7 +3722,7 @@ static	Uchar	jya[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sou[] = {
+static	u_char	sou[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3754,7 +3754,7 @@ static	Uchar	sou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mitai[] = {
+static	u_char	mitai[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3786,7 +3786,7 @@ static	Uchar	mitai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	yotte[] = {
+static	u_char	yotte[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3818,7 +3818,7 @@ static	Uchar	yotte[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	you2[] = {
+static	u_char	you2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3850,7 +3850,7 @@ static	Uchar	you2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sho[] = {
+static	u_char	sho[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -3882,7 +3882,7 @@ static	Uchar	sho[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	meisi[] = {
+static	u_char	meisi[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -3914,7 +3914,7 @@ static	Uchar	meisi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	wo_meisi[] = {
+static	u_char	wo_meisi[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -3946,7 +3946,7 @@ static	Uchar	wo_meisi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dmeisi[] = {
+static	u_char	dmeisi[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -3978,7 +3978,7 @@ static	Uchar	dmeisi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_o
 	};
 		
-static	Uchar	smeisi1[] = {
+static	u_char	smeisi1[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_o+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4010,7 +4010,7 @@ static	Uchar	smeisi1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	smeisi2[] = {
+static	u_char	smeisi2[] = {
 		wo_x+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_o+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4042,7 +4042,7 @@ static	Uchar	smeisi2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kstb[] = {
+static	u_char	kstb[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4074,7 +4074,7 @@ static	Uchar	kstb[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ichisetubi[] = {
+static	u_char	ichisetubi[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_o+ppoi_o+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4106,7 +4106,7 @@ static	Uchar	ichisetubi[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	josuusi[] = {
+static	u_char	josuusi[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4138,7 +4138,7 @@ static	Uchar	josuusi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	rentaisi[] = {
+static	u_char	rentaisi[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4170,7 +4170,7 @@ static	Uchar	rentaisi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	cut[] = {	
+static	u_char	cut[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4202,7 +4202,7 @@ static	Uchar	cut[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	shuujo[] = {
+static	u_char	shuujo[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4234,7 +4234,7 @@ static	Uchar	shuujo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	wo[] = {
+static	u_char	wo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4266,7 +4266,7 @@ static	Uchar	wo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	wo_s[] = {
+static	u_char	wo_s[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4298,7 +4298,7 @@ static	Uchar	wo_s[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	ttatte[] = {
+static	u_char	ttatte[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4330,7 +4330,7 @@ static	Uchar	ttatte[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ttara[] = {
+static	u_char	ttara[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4362,7 +4362,7 @@ static	Uchar	ttara[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tte1[] = {
+static	u_char	tte1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4394,7 +4394,7 @@ static	Uchar	tte1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tte2[] = {
+static	u_char	tte2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4426,7 +4426,7 @@ static	Uchar	tte2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ppanasi[] = {
+static	u_char	ppanasi[] = {
 		wo_o+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4458,7 +4458,7 @@ static	Uchar	ppanasi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ppoi[] = {
+static	u_char	ppoi[] = {
 		wo_x+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -4490,7 +4490,7 @@ static	Uchar	ppoi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ue[] = {
+static	u_char	ue[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4522,7 +4522,7 @@ static	Uchar	ue[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	uti[] = {
+static	u_char	uti[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -4554,7 +4554,7 @@ static	Uchar	uti[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	oite[] = {
+static	u_char	oite[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4586,7 +4586,7 @@ static	Uchar	oite[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	okeru[] = {	
+static	u_char	okeru[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4618,7 +4618,7 @@ static	Uchar	okeru[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ori[] = {
+static	u_char	ori[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4650,7 +4650,7 @@ static	Uchar	ori[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	ka1[] = {
+static	u_char	ka1[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -4683,7 +4683,7 @@ static	Uchar	ka1[] = {
 	};
 		
 		
-static	Uchar	ka2[] = {
+static	u_char	ka2[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4715,7 +4715,7 @@ static	Uchar	ka2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	katagata[] = {
+static	u_char	katagata[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4747,7 +4747,7 @@ static	Uchar	katagata[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kadouka[] = {
+static	u_char	kadouka[] = {
 		wo_o+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -4779,7 +4779,7 @@ static	Uchar	kadouka[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kamo[] = {
+static	u_char	kamo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4811,7 +4811,7 @@ static	Uchar	kamo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kara1[] = {
+static	u_char	kara1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_o,
@@ -4843,7 +4843,7 @@ static	Uchar	kara1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kara2[] = {
+static	u_char	kara2[] = {
 		wo_x+ttatte_o+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -4875,7 +4875,7 @@ static	Uchar	kara2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ga1[] = {
+static	u_char	ga1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4907,7 +4907,7 @@ static	Uchar	ga1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ga2[] = {
+static	u_char	ga2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4939,7 +4939,7 @@ static	Uchar	ga2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gatera[] = {
+static	u_char	gatera[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -4971,7 +4971,7 @@ static	Uchar	gatera[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kiri[] = {
+static	u_char	kiri[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5003,7 +5003,7 @@ static	Uchar	kiri[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kuseni[] = {
+static	u_char	kuseni[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5035,7 +5035,7 @@ static	Uchar	kuseni[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kurai[] = {
+static	u_char	kurai[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5067,7 +5067,7 @@ static	Uchar	kurai[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	gurumi[] = {
+static	u_char	gurumi[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5099,7 +5099,7 @@ static	Uchar	gurumi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kedo[] = {
+static	u_char	kedo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5131,7 +5131,7 @@ static	Uchar	kedo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	koso[] = {
+static	u_char	koso[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -5163,7 +5163,7 @@ static	Uchar	koso[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	koto[] = {
+static	u_char	koto[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5195,7 +5195,7 @@ static	Uchar	koto[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sae[] = {
+static	u_char	sae[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5227,7 +5227,7 @@ static	Uchar	sae[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	si2[] = {
+static	u_char	si2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5259,7 +5259,7 @@ static	Uchar	si2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sika[] = {
+static	u_char	sika[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5291,7 +5291,7 @@ static	Uchar	sika[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	sura[] = {
+static	u_char	sura[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -5323,7 +5323,7 @@ static	Uchar	sura[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	zutu[] = {
+static	u_char	zutu[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5355,7 +5355,7 @@ static	Uchar	zutu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tame[] = {
+static	u_char	tame[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -5387,7 +5387,7 @@ static	Uchar	tame[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tari[] = {
+static	u_char	tari[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5419,7 +5419,7 @@ static	Uchar	tari[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dake[] = {
+static	u_char	dake[] = {
 		wo_o+ttatte_o+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5451,7 +5451,7 @@ static	Uchar	dake[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dano[] = {
+static	u_char	dano[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_o,
@@ -5484,7 +5484,7 @@ static	Uchar	dano[] = {
 	};
 		
 
-static	Uchar	darake[] = {
+static	u_char	darake[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5516,7 +5516,7 @@ static	Uchar	darake[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tuite[] = {
+static	u_char	tuite[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -5548,7 +5548,7 @@ static	Uchar	tuite[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tuki[] = {
+static	u_char	tuki[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5580,7 +5580,7 @@ static	Uchar	tuki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tutu[] = {
+static	u_char	tutu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5612,7 +5612,7 @@ static	Uchar	tutu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tumori[] = {
+static	u_char	tumori[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_o,
@@ -5644,7 +5644,7 @@ static	Uchar	tumori[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	te1[] = {
+static	u_char	te1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5676,7 +5676,7 @@ static	Uchar	te1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	te2[] = {
+static	u_char	te2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_o+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_x,
@@ -5708,7 +5708,7 @@ static	Uchar	te2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	teru[] = {
+static	u_char	teru[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_o,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_o+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_o+ga1_x,
@@ -5740,7 +5740,7 @@ static	Uchar	teru[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	to1[] = {
+static	u_char	to1[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_o,
@@ -5772,7 +5772,7 @@ static	Uchar	to1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	to2[] = {
+static	u_char	to2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5804,7 +5804,7 @@ static	Uchar	to2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	totte[] = {
+static	u_char	totte[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5836,7 +5836,7 @@ static	Uchar	totte[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	toiu[] = {
+static	u_char	toiu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_o+kana_x+kane_x+kamo_x+kara1_x+kara2_o+ga1_x,
@@ -5868,7 +5868,7 @@ static	Uchar	toiu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	toori[] = {
+static	u_char	toori[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_o,
@@ -5900,7 +5900,7 @@ static	Uchar	toori[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	toki[] = {
+static	u_char	toki[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5932,7 +5932,7 @@ static	Uchar	toki[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tokoro[] = {
+static	u_char	tokoro[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -5964,7 +5964,7 @@ static	Uchar	tokoro[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tote[] = {
+static	u_char	tote[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -5996,7 +5996,7 @@ static	Uchar	tote[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tohaie[] = {
+static	u_char	tohaie[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6028,7 +6028,7 @@ static	Uchar	tohaie[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	tomo[] = {
+static	u_char	tomo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6060,7 +6060,7 @@ static	Uchar	tomo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	fdo[] = {
+static	u_char	fdo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6092,7 +6092,7 @@ static	Uchar	fdo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	doori[] = {
+static	u_char	doori[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6124,7 +6124,7 @@ static	Uchar	doori[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dokoro[] = {
+static	u_char	dokoro[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6156,7 +6156,7 @@ static	Uchar	dokoro[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	dokoroka[] = {
+static	u_char	dokoroka[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6188,7 +6188,7 @@ static	Uchar	dokoroka[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	domo[] = {
+static	u_char	domo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6220,7 +6220,7 @@ static	Uchar	domo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nagara[] = {
+static	u_char	nagara[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -6252,7 +6252,7 @@ static	Uchar	nagara[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nagara2[] = {
+static	u_char	nagara2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -6284,7 +6284,7 @@ static	Uchar	nagara2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	nazo[] = {
+static	u_char	nazo[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_o,
@@ -6316,7 +6316,7 @@ static	Uchar	nazo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nado[] = {
+static	u_char	nado[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6348,7 +6348,7 @@ static	Uchar	nado[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nari[] = {
+static	u_char	nari[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_o,
@@ -6380,7 +6380,7 @@ static	Uchar	nari[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nanka[] = {
+static	u_char	nanka[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_o,
@@ -6412,7 +6412,7 @@ static	Uchar	nanka[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nanzo[] = {
+static	u_char	nanzo[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_o+kara2_x+ga1_o,
@@ -6444,7 +6444,7 @@ static	Uchar	nanzo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nante[] = {
+static	u_char	nante[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6476,7 +6476,7 @@ static	Uchar	nante[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ni1[] = {
+static	u_char	ni1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_o+okeru_o+ori_x+ka1_x+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -6508,7 +6508,7 @@ static	Uchar	ni1[] = {
 		yasui_x+yoi_x+yaru_o
 	};
 		
-static	Uchar	ni2[] = {
+static	u_char	ni2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6540,7 +6540,7 @@ static	Uchar	ni2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ni3[] = {
+static	u_char	ni3[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6572,7 +6572,7 @@ static	Uchar	ni3[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nite[] = {
+static	u_char	nite[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6604,7 +6604,7 @@ static	Uchar	nite[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nimo[] = {
+static	u_char	nimo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6636,7 +6636,7 @@ static	Uchar	nimo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	no1[] = {
+static	u_char	no1[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_o+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6668,7 +6668,7 @@ static	Uchar	no1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	no2[] = {
+static	u_char	no2[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6700,7 +6700,7 @@ static	Uchar	no2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	node[] = {
+static	u_char	node[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6732,7 +6732,7 @@ static	Uchar	node[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	noni[] = {
+static	u_char	noni[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6764,7 +6764,7 @@ static	Uchar	noni[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nomi[] = {
+static	u_char	nomi[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6796,7 +6796,7 @@ static	Uchar	nomi[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nominrz[] = {
+static	u_char	nominrz[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6828,7 +6828,7 @@ static	Uchar	nominrz[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ha[] = {
+static	u_char	ha[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6860,7 +6860,7 @@ static	Uchar	ha[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	hazu[] = {
+static	u_char	hazu[] = {
 		wo_x+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -6892,7 +6892,7 @@ static	Uchar	hazu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ba[] = {
+static	u_char	ba[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6924,7 +6924,7 @@ static	Uchar	ba[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	bakari[] = {
+static	u_char	bakari[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -6956,7 +6956,7 @@ static	Uchar	bakari[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	he[] = {
+static	u_char	he[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -6988,7 +6988,7 @@ static	Uchar	he[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	hou[] = {
+static	u_char	hou[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -7020,7 +7020,7 @@ static	Uchar	hou[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	hoka[] = {
+static	u_char	hoka[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7052,7 +7052,7 @@ static	Uchar	hoka[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	hodo[] = {
+static	u_char	hodo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -7084,7 +7084,7 @@ static	Uchar	hodo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	made[] = {
+static	u_char	made[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_x+kara2_x+ga1_o,
@@ -7116,7 +7116,7 @@ static	Uchar	made[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mama[] = {
+static	u_char	mama[] = {
 		wo_o+ttatte_x+ttara_o+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -7148,7 +7148,7 @@ static	Uchar	mama[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mo1[] = {
+static	u_char	mo1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7180,7 +7180,7 @@ static	Uchar	mo1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mo2[] = {
+static	u_char	mo2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -7212,7 +7212,7 @@ static	Uchar	mo2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	motte[] = {
+static	u_char	motte[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7244,7 +7244,7 @@ static	Uchar	motte[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	mono[] = {
+static	u_char	mono[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_o+kara1_o+kara2_x+ga1_o,
@@ -7276,7 +7276,7 @@ static	Uchar	mono[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ya1[] = {
+static	u_char	ya1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7308,7 +7308,7 @@ static	Uchar	ya1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	ya2[] = {
+static	u_char	ya2[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7340,7 +7340,7 @@ static	Uchar	ya2[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	yara[] = {
+static	u_char	yara[] = {
 		wo_o+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -7372,7 +7372,7 @@ static	Uchar	yara[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	yue[] = {
+static	u_char	yue[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7404,7 +7404,7 @@ static	Uchar	yue[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	yori1[] = {
+static	u_char	yori1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7436,7 +7436,7 @@ static	Uchar	yori1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	wake[] = {
+static	u_char	wake[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_o+kai_x+kasira_o,
 		katagata_x+kadouka_o+kana_o+kane_o+kamo_x+kara1_x+kara2_x+ga1_o,
@@ -7468,7 +7468,7 @@ static	Uchar	wake[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	nn1[] = {
+static	u_char	nn1[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7500,7 +7500,7 @@ static	Uchar	nn1[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	aisatu[] = {
+static	u_char	aisatu[] = {
 		wo_o+ttatte_x+ttara_x+tte1_o+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7532,7 +7532,7 @@ static	Uchar	aisatu[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	kosodo[] = {
+static	u_char	kosodo[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_o+ka2_x+kai_x+kasira_o,
 		katagata_x+kadouka_x+kana_o+kane_x+kamo_o+kara1_x+kara2_x+ga1_x,
@@ -7564,7 +7564,7 @@ static	Uchar	kosodo[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 		
-static	Uchar	site[] = {
+static	u_char	site[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_x+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7596,7 +7596,7 @@ static	Uchar	site[] = {
 		yasui_x+yoi_x+yaru_x+ttarasii_x
 	};
 
-static	Uchar	n_si[] = {
+static	u_char	n_si[] = {
 		wo_x+ttatte_x+ttara_x+tte1_x+tte2_x+ppanasi_o+ppoi_x+ue_x,
 		uti_x+oite_x+okeru_x+ori_x+ka1_x+ka2_x+kai_x+kasira_x,
 		katagata_x+kadouka_x+kana_x+kane_x+kamo_x+kara1_x+kara2_x+ga1_x,
@@ -7628,7 +7628,7 @@ static	Uchar	n_si[] = {
 		yasui_o+yoi_x+yaru_x+ttarasii_x
 	};
 
-Uchar	connadr[] = {
+u_char	connadr[] = {
 		0,			
 		R_MEISI,		
 		R_MEISI,		
@@ -7854,7 +7854,7 @@ Uchar	connadr[] = {
 		R_MEISI			
 	};
 
-Uchar	*rigtadr[] = {
+u_char	*rigtadr[] = {
 		0,		
 		de,		
 		wo,		

--- a/const.h
+++ b/const.h
@@ -138,25 +138,25 @@
 #define	K_RENTAISI	5	
 #define	K_SONOTA	6	
 
-#define EUC_a1          (Uchar)0xa1
-#define EUC_a2          (Uchar)0xa2
-#define EUC_a3          (Uchar)0xa3
-#define EUC_a4          (Uchar)0xa4
-#define EUC_a5          (Uchar)0xa5
+#define EUC_a1          (u_char)0xa1
+#define EUC_a2          (u_char)0xa2
+#define EUC_a3          (u_char)0xa3
+#define EUC_a4          (u_char)0xa4
+#define EUC_a5          (u_char)0xa5
 
-#define EUC_START       (Uchar)0xa1
-#define EUC_END         (Uchar)0xfe
-#define EUC_END_KIGOU   (Uchar)0xae
-#define EUC_0           (Uchar)0xb0
-#define EUC_END_0       (Uchar)0xb9
-#define EUC_A           (Uchar)0xc1
-#define EUC_END_A       (Uchar)0xda
-#define EUC_a           (Uchar)0xe1
-#define EUC_END_a       (Uchar)0xfa
-#define EUC_END_HIRA    (Uchar)0xf3
-#define EUC_VU          (Uchar)0xf4
-#define EUC_XKA         (Uchar)0xf5
-#define EUC_XKE         (Uchar)0xf6
+#define EUC_START       (u_char)0xa1
+#define EUC_END         (u_char)0xfe
+#define EUC_END_KIGOU   (u_char)0xae
+#define EUC_0           (u_char)0xb0
+#define EUC_END_0       (u_char)0xb9
+#define EUC_A           (u_char)0xc1
+#define EUC_END_A       (u_char)0xda
+#define EUC_a           (u_char)0xe1
+#define EUC_END_a       (u_char)0xfa
+#define EUC_END_HIRA    (u_char)0xf3
+#define EUC_VU          (u_char)0xf4
+#define EUC_XKA         (u_char)0xf5
+#define EUC_XKE         (u_char)0xf6
 
 #define	isknj1(c)	(((c) == SS2) || (((c) & 0x80) && ((c) != SS3)))
 

--- a/cvtclknj.c
+++ b/cvtclknj.c
@@ -41,14 +41,14 @@
 
 
 
-Void	cvtkouho(), setstyrec();
+void	cvtkouho(), setstyrec();
 
 
 
-Void	cvtclknj()
+void	cvtclknj()
 {
 	KHREC	*krec;
-	Int	i;
+	int	i;
 
 	
 
@@ -59,7 +59,7 @@ Void	cvtclknj()
 	krec = kouhotbl;		
 
 	while (i--) {
-		if ((Int)krec -> rank == (Int)selectid) break;
+		if ((int)krec -> rank == (int)selectid) break;
 		krec++;
 	}
 

--- a/cvtdict.c
+++ b/cvtdict.c
@@ -46,14 +46,14 @@ void
 cvtdict(KHREC *krec, CLREC *clrec, int flg)
 {
 	TypeDicOfs	ofs;		
-	Uchar		*yptr;		
-	Int		jlen;		
-	Int		stblen;		
-	Int		sttlen;		
-	Uchar		*fptr;
-	Int		cllen;
+	u_char		*yptr;
+	int		jlen;
+	int		stblen;
+	int		sttlen;
+	u_char		*fptr;
+	int		cllen;
 	JREC		*jrec;
-	Int		i, j;
+	int		i, j;
 
 	
 	ofs   = krec -> offs;
@@ -160,9 +160,9 @@ cvtdict(KHREC *krec, CLREC *clrec, int flg)
 
 
 void
-cvtminasi(Int len)
+cvtminasi(int len)
 {
-	Uchar	*ptr;		
+	u_char	*ptr;
 
 	ptr = inputyomi;	
 
@@ -189,10 +189,10 @@ cvtminasi(Int len)
 void
 cvtwakachi(CLREC *clrec)
 {
-	Int	jlen;	
-	Uchar	*ym;
-	Int	cnt;
-	Uchar	ch;
+	int	jlen;
+	u_char	*ym;
+	int	cnt;
+	u_char	ch;
 
 	ym = inputyomi;		
 

--- a/cvtkanji.c
+++ b/cvtkanji.c
@@ -41,16 +41,16 @@
 #include "kanakan.h"
 
 
-Void	mkknjmax();
-Void	mvmemi(), free_clall();
-Void	free_jall();
+void	mkknjmax();
+void	mvmemi(), free_clall();
+void	free_jall();
 
 
 
 void
 cvtphknj (void)
 {
-	Int	i, j;
+	int	i, j;
 	CLREC	*clrec;
 	CLREC	*clkp;
 
@@ -93,8 +93,8 @@ cvtphknj (void)
 		
                 ystart += clt1st -> cllen;
 
-                j = hzstrlen(inputyomi, (Int)clt1st -> cllen);
-		kanjibuf[0] = (Uchar)j;
+                j = hzstrlen(inputyomi, (int)clt1st -> cllen);
+		kanjibuf[0] = (u_char)j;
 
 		
 		inputyomi += j;
@@ -143,7 +143,7 @@ cvtkouho (KHREC *krec)
 
 	case C_BUNSETU :		
 	case C_MINASI  :		
-		cvtminasi((Int)clrec -> cllen);
+		cvtminasi((int)clrec -> cllen);
 		break;
 
 	case C_WAKACHI :		
@@ -162,8 +162,8 @@ setstyrec (KHREC *krec)
 {
 	JREC	*jrec;
 	KHREC	*kptr;
-	Int	ii;
-	Uchar	*fptr;
+	int	ii;
+	u_char	*fptr;
 	STDYOUT	stdy;
 
 	jrec  = krec -> clrec -> jnode;
@@ -207,7 +207,7 @@ setstyrec (KHREC *krec)
 		stdy.sttlen = 0;
 
 	
-	memcpy((Uchar *)&stdy, kanjitmp, sizeof(STDYOUT));
+	memcpy((u_char *)&stdy, kanjitmp, sizeof(STDYOUT));
 	kanjitmp += sizeof(STDYOUT);
 }
 

--- a/depend.c
+++ b/depend.c
@@ -300,9 +300,9 @@ opendict(char* name, char* passwd)
 	}
 
 #if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__bsdi__) || defined(__DragonFly__)
-	if ((dp = (Uchar *)malloc((long)sbuf.st_size)) == NULL) {
+	if ((dp = (u_char *)malloc((long)sbuf.st_size)) == NULL) {
 #else
-	if ((dp = (Uchar *)malloc(sbuf.st_size)) == NULL) {
+	if ((dp = (u_char *)malloc(sbuf.st_size)) == NULL) {
 #endif
 		serv_errno = SJ3_NotEnoughMemory; goto error1;
 	}
@@ -437,7 +437,7 @@ openstdy(char* name, char* passwd)
 	StdyFile	*sfp;
 	u_char		*hd;
 	STDYIN		*sp;
-	Ushort		*cip;
+	u_short		*cip;
 	u_char		*clp;
 	long		stdycnt, stdypos, stdylen, stdymax;
 	long		clidxpos, clidxlen;
@@ -502,7 +502,7 @@ openstdy(char* name, char* passwd)
 	if ((sp = (STDYIN *)malloc(len)) == NULL) {
 		serv_errno = SJ3_NotEnoughMemory; goto error2;
 	}
-	if ((cip = (Ushort *)malloc(clidxlen)) == NULL) {
+	if ((cip = (u_short *)malloc(clidxlen)) == NULL) {
 		serv_errno = SJ3_NotEnoughMemory; goto error3;
 	}
 	if ((clp = (u_char *)malloc(clstdylen)) == NULL) {
@@ -711,7 +711,7 @@ makestdy(char* path, int stynum, int clstep, int cllen)
 	put4byte(tmp + VersionPos, StdyVersion);
 
 	
-	j = 256 * sizeof(Ushort);
+	j = 256 * sizeof(u_short);
 	put4byte(tmp + StdyClIdxPos, pos);
 	put4byte(tmp + StdyClIdxLen, j);
 	put4byte(tmp + StdyClIdxStep, clstep);

--- a/execute.c
+++ b/execute.c
@@ -69,18 +69,18 @@ extern	char	*dict_dir;
 extern	int	dir_mode;
 extern	int	file_mode;
 
-static	Uchar	buf1[YomiBufSize];
-static	Uchar	buf2[YomiBufSize];
-static	Uchar	buf3[YomiBufSize];
-static	Uchar	buf4[YomiBufSize];
-static	Uchar	kbuf[KanjiBufSize];
-static	Uchar	skbuf[KanjiBufSize];
+static	u_char	buf1[YomiBufSize];
+static	u_char	buf2[YomiBufSize];
+static	u_char	buf3[YomiBufSize];
+static	u_char	buf4[YomiBufSize];
+static	u_char	kbuf[KanjiBufSize];
+static	u_char	skbuf[KanjiBufSize];
 
 static	jmp_buf	error_ret;
 static	WorkArea *worklist = NULL;	
 static	Client	*cur_cli;		
 
-static Uchar defaultchar[2] = {(Uchar)0x81, (Uchar)0x40};   
+static u_char defaultchar[2] = {(u_char)0x81, (u_char)0x40};
 static int  defuse=0, defuse2=0;
 
 DictFile *opendict();
@@ -88,7 +88,7 @@ int	closedict();
 StdyFile *openstdy();
 int	closestdy();
 
-Uchar	*put_ndata(), *put_string();
+u_char	*put_ndata(), *put_string();
 
 
 
@@ -488,7 +488,7 @@ void
 exec_ph2knj (int mb_flag)
 {
 	int	i, j, l, stdy_size, buf_size, srchead = 0, srclen;
-	Uchar	*p,*q;
+	u_char	*p,*q;
 
 	i = get_nstring(buf1, sizeof(buf1));
 
@@ -566,7 +566,7 @@ exec_cl2knj (int mb_flag)
 {
 	int	len, stdy_size, buf_size;
 	int	i, j, l;
-	Uchar	*ptr, *q;
+	u_char	*ptr, *q;
 
 	len = get_int();
 	i = get_nstring(buf1, sizeof(buf1));
@@ -631,7 +631,7 @@ exec_nextcl (int mb_flag)
 {
 	int	mode, stdy_size, buf_size;
 	int	i, l;
-	Uchar	*ptr, *q;
+	u_char	*ptr, *q;
 
 	mode = get_int();
 
@@ -684,7 +684,7 @@ exec_prevcl (int mb_flag)
 {
 	int	mode, stdy_size, buf_size;
 	int	i, l;
-	Uchar	*ptr, *q;
+	u_char	*ptr, *q;
 
 	mode = get_int();
 
@@ -786,7 +786,7 @@ exec_cl2knj_all (int mb_flag)
 {
 	int	len, stdy_size, buf_size;
 	int	i, l;
-	Uchar	*ptr, *q;
+	u_char	*ptr, *q;
 
 	len = get_int();
 	i = get_nstring(buf1, sizeof(buf1));
@@ -1084,7 +1084,7 @@ exec_getdict (int mb_flag)
 	TypeDicID	dicid;
 	int		err, buf_size, l;
 	DICTL		*dl;
-	Uchar		*ptr, *q;
+	u_char		*ptr, *q;
 
 	
 	dicid = get_int();
@@ -1168,7 +1168,7 @@ exec_nextdict (int mb_flag)
 	TypeDicID	dicid;
 	int		err, buf_size, l;
 	DICTL		*dl;
-	Uchar		*ptr, *q;
+	u_char		*ptr, *q;
 
 	
 	dicid = get_int();
@@ -1252,7 +1252,7 @@ exec_prevdict (int mb_flag)
 	TypeDicID	dicid;
 	int		err, buf_size, l;
 	DICTL		*dl;
-	Uchar		*ptr, *q;
+	u_char		*ptr, *q;
 
 	
 	dicid = get_int();

--- a/fuzoku.c
+++ b/fuzoku.c
@@ -45,16 +45,16 @@
 
 
 CLREC	*argclrec();
-Int	terminate();
+int	terminate();
 
 
 
-Static	Int	fzkstrcmp(yptr, fzkp, saml)
-Uchar	*yptr;
-Uchar	TFar	*fzkp;		
-Int	*saml;			
+Static	int	fzkstrcmp(yptr, fzkp, saml)
+u_char	*yptr;
+u_char	*fzkp;
+int	*saml;
 {
-	Int	asklen, nkrlen;
+	int	asklen, nkrlen;
 
 	asklen = FzkAskLen(fzkp);
 
@@ -93,14 +93,14 @@ Int	*saml;
 
 
 
-Void	setclrec(jrec, yptr, right)
+void	setclrec(jrec, yptr, right)
 JREC		*jrec;		
-Uchar		*yptr;		
+u_char		*yptr;
 TypeCnct	right;		
 {
 	CLREC		*new;
 	TypeGram	hinsi;
-	Int		len;
+	int		len;
 
 	
 	if (!(len = yptr - cnvstart)) return;
@@ -181,11 +181,11 @@ TypeCnct	right;
 		new -> kubun = K_TAIGEN;
 }
 
-Static	Int	fzkcnct(right, left)
+Static	int	fzkcnct(right, left)
 TypeCnct	right;
 TypeCnct	left;
 {
-	Uchar	TFar	*cncttbl;
+	u_char	*cncttbl;
 
 	if (right && left) {
 		cncttbl = Rigtadr(right);
@@ -197,20 +197,19 @@ TypeCnct	left;
 	return FALSE;
 }
 
-RECURS
-Void	srchfzk(jrec, yptr, right, level)
+void	srchfzk(jrec, yptr, right, level)
 JREC		*jrec;			
-Uchar		*yptr;
+u_char		*yptr;
 TypeCnct	right;			
-Int		level;			
+int		level;
 {
-	Uchar	TFar	*fzk;	
-	Int	len = 0;	
-	Int	cmp;		
-	Uchar	*next;		
+	u_char	*fzk;
+	int	len = 0;
+	int	cmp;
+	u_char	*next;
 	FREC	*fzkrec;	
-	Int	i;		
-	Int	nlen;
+	int	i;
+	int	nlen;
 	TypeCnct	rt;
 
 	if ((level >= MAXFLVL) && !(Chrtbl[*yptr] & FZK_KGU)) return;

--- a/fzkyomi.c
+++ b/fzkyomi.c
@@ -42,13 +42,13 @@
 #include "sj_right.h"
 #include "sj_left.h"
 
-static	Uchar	fzk_wo[] = {
+static	u_char	fzk_wo[] = {
 (0<<5)+0,			L_WO,      R_WO,
 (0<<5)+0,			L_WO_S,	   R_WO_S,
 0xff
 };
 
-static	Uchar	fzk_xtu[] = {
+static	u_char	fzk_xtu[] = {
 (0<<5) + 1,	_KE,		L_KKE,	   R_SHUUJO,
 (0<<5) + 3,	_TA,_XTU,_TE,	L_TTATTE,  R_TTATTE,
 (1<<5) + 1,	_RA,		L_TTARA,   R_TTARA,
@@ -69,7 +69,7 @@ static	Uchar	fzk_xtu[] = {
 0xff
 };
 
-static	Uchar	fzk_a[] = {
+static	u_char	fzk_a[] = {
 (0<<5) + 1,	_GE,		L_YOUGEN, R_AGE,
 (1<<5) + 1,	_YO,		L_YOUGEN, R_MEIREI2,
 (1<<5) + 1,	_RU,		L_YOUGEN, R_SHUUSI,
@@ -88,7 +88,7 @@ static	Uchar	fzk_a[] = {
 0xff
 };
 
-static	Uchar	fzk_i[] = {
+static	u_char	fzk_i[] = {
 (0<<5) + 0,			L_IRU,     R_I,
 (0<<5) + 1,	_I,		L_II,	   R_SHUUSI,
 (0<<5) + 1,	_KA,		L_YOUGEN,  R_MIZEN5,
@@ -111,21 +111,21 @@ static	Uchar	fzk_i[] = {
 0xff
 };
 
-static	Uchar	fzk_u[] = {
+static	u_char	fzk_u[] = {
 (0<<5) + 1,	_E,		L_UE,      R_UE,
 (0<<5) + 1,	_TI,		L_UTI,	   R_UTI,
 (0<<5) + 1,	_RU,		L_ERU,     R_SHUUSI,
 0xff
 };
 
-static	Uchar	fzk_e[] = {
+static	u_char	fzk_e[] = {
 (0<<5) + 0,			L_ERU,     R_E,
 (0<<5) + 1,	_RU,		L_ERU,	   R_SHUUSI,
 (0<<5) + 1,	_RE,		L_ERU,     R_KATEI3,
 0xff
 };
 
-static	Uchar	fzk_o[] = {
+static	u_char	fzk_o[] = {
 (0<<5) + 1,	_I,		L_YOUGEN,  R_ONBIN8,
 (1<<5) + 1,	_TE,		L_OITE,    R_OITE,
 (0<<5) + 1,	_KA,		L_YOUGEN,  R_MIZEN5,
@@ -141,7 +141,7 @@ static	Uchar	fzk_o[] = {
 0xff
 };
 
-static	Uchar	fzk_ka[] = {
+static	u_char	fzk_ka[] = {
 (0<<5) + 0 + 8,			L_KA1,     R_KA1,
 (0<<5) + 0 + 8,			L_KA2,     R_KA2,
 (0<<5) + 1,	_I,		L_KAI,	   R_SHUUJO,
@@ -166,7 +166,7 @@ static	Uchar	fzk_ka[] = {
 0xff
 };
 
-static	Uchar	fzk_ga[] = {
+static	u_char	fzk_ga[] = {
 (0<<5) + 0,			L_GA1,     R_GA1,
 (0<<5) + 0,			L_GA2,     R_GA2,
 (0<<5) + 2,	_TA,_I,		L_GATAI,   R_KSHUUSI,
@@ -186,13 +186,13 @@ static	Uchar	fzk_ga[] = {
 0xff
 };
 
-static	Uchar	fzk_ki[] = {
+static	u_char	fzk_ki[] = {
 (0<<5) + 0,			L_YOUGEN,  R_FZKKI,
 (0<<5) + 1,	_RI,		L_KIRI,    R_KIRI,
 0xff
 };
 
-static	Uchar	fzk_ku[] = {
+static	u_char	fzk_ku[] = {
 (0<<5) + 2,	_SE,_NI,	L_KUSENI,   R_KUSENI,
 (0<<5) + 3,	_DA,_SA,_I,	L_KUDASARU, R_KUDASAI,
 (2<<5) + 1,	_XTU,		L_KUDASARU, R_ONBIN6,
@@ -208,13 +208,13 @@ static	Uchar	fzk_ku[] = {
 0xff
 };
 
-static	Uchar	fzk_gu[] = {
+static	u_char	fzk_gu[] = {
 (0<<5) + 2,	_RA,_I,		L_KURAI,    R_KURAI,
 (0<<5) + 2,	_RU,_MI,	L_GURUMI,   R_GURUMI,
 0xff
 };
 
-static	Uchar	fzk_ke[] = {
+static	u_char	fzk_ke[] = {
 (0<<5) + 1,	_DO,		L_KEDO,     R_KEDO,
 (1<<5) + 1,	_MO,		L_KEDO,     R_KEDO,
 (0<<5) + 2,	_RE,_DO,	L_KEDO,     R_KEDO,
@@ -222,7 +222,7 @@ static	Uchar	fzk_ke[] = {
 0xff
 };
 
-static	Uchar	fzk_ko[] = {
+static	u_char	fzk_ko[] = {
 (0<<5) + 0,			L_YOUGEN,   R_KO,
 (0<<5) + 1,	_I,		L_YOUGEN,   R_MEIREI1,
 (0<<5) + 1,	_SO,		L_KOSO,     R_KOSO,
@@ -230,7 +230,7 @@ static	Uchar	fzk_ko[] = {
 0xff
 };
 
-static	Uchar	fzk_go[] = {
+static	u_char	fzk_go[] = {
 (0<<5) + 2,	_ZA,_I,		L_GOZAI,    R_GOZAI,
 (0<<5) + 2,	_TO,_KI,	L_GOTOSI,   R_GOTOKI,
 (1<<5) + 1,	_KU,		L_GOTOSI,   R_GOTOKU,
@@ -238,7 +238,7 @@ static	Uchar	fzk_go[] = {
 0xff
 };
 
-static	Uchar	fzk_sa[] = {
+static	u_char	fzk_sa[] = {
 (0<<5) + 0,			L_SA1,      R_MIZEN1,
 (0<<5) + 0,			L_SA2,      R_SHUUJO,
 (0<<5) + 1,	_E,		L_SAE,      R_SAE,
@@ -250,13 +250,13 @@ static	Uchar	fzk_sa[] = {
 0xff
 };
 
-static	Uchar	fzk_za[] = {
+static	u_char	fzk_za[] = {
 (0<<5) + 1,	_RU,		L_ZARU,     R_ZARU,
 (0<<5) + 1,	_RE,		L_ZARU,     R_KATEI2,
 0xff
 };
 
-static	Uchar	fzk_si[] = {
+static	u_char	fzk_si[] = {
 (0<<5) + 0,			L_SI1,      R_SI1,
 (0<<5) + 0,			L_SI2,      R_SI2,
 (0<<5) + 0,			L_N_SI,	    R_N_SI,
@@ -272,7 +272,7 @@ static	Uchar	fzk_si[] = {
 0xff
 };
 
-static	Uchar	fzk_ji[] = {
+static	u_char	fzk_ji[] = {
 (0<<5) + 2,	_MA,_I,		L_JIMAU,    R_IKI,
 (1<<5) + 1,	_U,		L_JIMAU,    R_SHUUSI,
 (1<<5) + 1,	_E,		L_JIMAU,    R_IKE,
@@ -289,7 +289,7 @@ static	Uchar	fzk_ji[] = {
 0xff
 };
 
-static	Uchar	fzk_su[] = {
+static	u_char	fzk_su[] = {
 (0<<5) + 1,	_GI,		L_SUGIRU,   R_SUGI,
 (1<<5) + 1,	_RU,		L_SUGIRU,   R_SHUUSI,
 (1<<5) + 1,	_RE,		L_SUGIRU,   R_KATEI2,
@@ -303,7 +303,7 @@ static	Uchar	fzk_su[] = {
 0xff
 };
 
-static	Uchar	fzk_zu[] = {
+static	u_char	fzk_zu[] = {
 (0<<5) + 0,			L_ZU,       R_ZU,
 (0<<5) + 1,	_TU,		L_ZUTU,	    R_ZUTU,
 (0<<5) + 2,	_NI,_I,		L_ZU,	    R_I,
@@ -312,7 +312,7 @@ static	Uchar	fzk_zu[] = {
 0xff
     };
 
-static	Uchar	fzk_se[] = {
+static	u_char	fzk_se[] = {
 (0<<5) + 0,			L_SE,       R_MIZEN2,
 (0<<5) + 0,			L_SERU,     R_SASE,
 (0<<5) + 1,	_YO,		L_SEYO,     R_MEIREI2,
@@ -323,12 +323,12 @@ static	Uchar	fzk_se[] = {
 0xff
 };
 
-static	Uchar	fzk_ze[] = {
+static	u_char	fzk_ze[] = {
 (0<<5) + 0,			L_ZE,	    R_SHUUJO,
 0xff
 };
 
-static	Uchar	fzk_so[] = {
+static	u_char	fzk_so[] = {
 (0<<5) + 1,	_U,		L_SOUDA,    R_SOU,
 (1<<5) + 1,	_DA,		L_SOUDA,    R_SOUDA,
 (2<<5) + 1,	_XTU,		L_YOUTAI,   R_ONBIN1,
@@ -345,12 +345,12 @@ static	Uchar	fzk_so[] = {
 0xff
 };
 
-static	Uchar	fzk_zo[] = {
+static	u_char	fzk_zo[] = {
 (0<<5) + 0,			L_ZO,       R_SHUUJO,
 0xff
 };
 
-static	Uchar	fzk_ta[] = {
+static	u_char	fzk_ta[] = {
 (0<<5) + 0,			L_TA,       R_TA,
 (0<<5) + 1,	_I,		L_TAI,      R_TAI,
 (0<<5) + 2,	_KA,_XTU,	L_TAI,      R_ONBIN1,
@@ -376,7 +376,7 @@ static	Uchar	fzk_ta[] = {
 0xff
 };
 
-static	Uchar	fzk_da[] = {
+static	u_char	fzk_da[] = {
 (0<<5) + 0,			L_DA1,	    R_TA,
 (0<<5) + 0,			L_DA2,      R_DSHUUSI1,
 (0<<5) + 1,	_KE,		L_DAKE,     R_DAKE,
@@ -389,7 +389,7 @@ static	Uchar	fzk_da[] = {
 0xff
 };
 
-static	Uchar	fzk_ti[] = {
+static	u_char	fzk_ti[] = {
 (0<<5) + 2,	_MA,_I,		L_TIMAU,    R_IKI,
 (1<<5) + 1,	_U,		L_TIMAU,    R_SHUUSI,
 (1<<5) + 1,	_E,		L_TIMAU,    R_IKE,
@@ -406,12 +406,12 @@ static	Uchar	fzk_ti[] = {
 0xff
 };
 
-static	Uchar	fzk_di[] = {
+static	u_char	fzk_di[] = {
 (0<<5) + 1,	_XYA,		L_JYA,      R_JYA,
 0xff
 };
 
-static	Uchar	fzk_tu[] = {
+static	u_char	fzk_tu[] = {
 (0<<5) + 2,	_I,_TE,		L_TUITE,    R_TUITE,
 (0<<5) + 1,	_KI,		L_TUKI,     R_TUKI,
 (0<<5) + 1,	_TU,		L_TUTU,     R_TUTU,
@@ -419,14 +419,14 @@ static	Uchar	fzk_tu[] = {
 0xff
 };
 
-static	Uchar	fzk_te[] = {
+static	u_char	fzk_te[] = {
 (0<<5) + 0,			L_TE1,      R_TE1,
 (0<<5) + 0,			L_TE2,      R_TE2,
 (0<<5) + 1,	_RU,		L_TERU,     R_TERU,
 0xff
 };
 
-static	Uchar	fzk_de[] = {
+static	u_char	fzk_de[] = {
 (0<<5) + 0,			L_DE,       R_DE,
 (0<<5) + 0,			L_DA1,      R_TE2,
 (0<<5) + 3,	_A,_RO,_U,	L_DEAROU,   R_AROU,
@@ -442,7 +442,7 @@ static	Uchar	fzk_de[] = {
 0xff
 };
 
-static	Uchar	fzk_to[] = {
+static	u_char	fzk_to[] = {
 (0<<5) + 0,			L_TO1,      R_TO1,
 (0<<5) + 0,			L_TO2,      R_TO2,
 (0<<5) + 1,	_I,		L_TE2,      R_ONBIN8,
@@ -463,7 +463,7 @@ static	Uchar	fzk_to[] = {
 0xff
 };
 
-static	Uchar	fzk_do[] = {
+static	u_char	fzk_do[] = {
 (0<<5) + 0,			L_DO,       R_DO,
 (0<<5) + 1,	_I,		L_DA1,      R_ONBIN8,
 (0<<5) + 2,	_O,_RI,		L_DOORI,    R_DOORI,
@@ -478,7 +478,7 @@ static	Uchar	fzk_do[] = {
 0xff
 };
 
-static	Uchar	fzk_na[] = {
+static	u_char	fzk_na[] = {
 (0<<5) + 0,			L_NA1,      R_SHUUJO,
 (0<<5) + 0,			L_NA2,      R_NA2,
 (0<<5) + 1,	_XA,		L_NAA,      R_SHUUJO,
@@ -515,7 +515,7 @@ static	Uchar	fzk_na[] = {
 0xff
 };
 
-static	Uchar	fzk_ni[] = {
+static	u_char	fzk_ni[] = {
 (0<<5) + 0,			L_NI1,      R_NI1,
 (0<<5) + 0,			L_NI2,      R_NI2,
 (0<<5) + 0,			L_NI3,      R_NI3,
@@ -531,19 +531,19 @@ static	Uchar	fzk_ni[] = {
 0xff
 };
 
-static	Uchar	fzk_nu[] = {
+static	u_char	fzk_nu[] = {
 (0<<5) + 0,			L_NU,       R_NU,
 0xff
 };
 
-static	Uchar	fzk_ne[] = {
+static	u_char	fzk_ne[] = {
 (0<<5) + 0,			L_NE1,      R_SHUUJO,
 (0<<5) + 0,			L_NE2,      R_KATEI2,
 (0<<5) + 1,	_E,		L_NEE,      R_SHUUJO,
 0xff
 };
 
-static	Uchar	fzk_no[] = {
+static	u_char	fzk_no[] = {
 (0<<5) + 0,			L_NO1,      R_NO1,
 (0<<5) + 0,			L_NO2,      R_NO2,
 (0<<5) + 1,	_DE,		L_NODE,     R_NODE,
@@ -553,14 +553,14 @@ static	Uchar	fzk_no[] = {
 0xff
 };
 
-static	Uchar	fzk_ha[] = {
+static	u_char	fzk_ha[] = {
 (0<<5) + 0,			L_HA,       R_HA,
 (0<<5) + 1,	_SI,		L_HA,	    R_HASI,
 (0<<5) + 1,	_ZU,		L_HAZU,     R_HAZU,
 0xff
 };
 
-static	Uchar	fzk_ba[] = {
+static	u_char	fzk_ba[] = {
 (0<<5) + 0,			L_BA,       R_BA,
 (0<<5) + 2,	_KA,_SI,	L_BAKARI,   R_BAKARI,
 (1<<5) + 1,	_RI,		L_BAKARI,   R_BAKARI,
@@ -569,7 +569,7 @@ static	Uchar	fzk_ba[] = {
 0xff
 };
 
-static	Uchar	fzk_hu[] = {
+static	u_char	fzk_hu[] = {
 (0<<5) + 2,	_U,_DA,		L_FUUDA,    R_SOUDA,
 (2<<5) + 1,	_XTU,		L_FUUDA,    R_ONBIN1,
 (2<<5) + 2,	_RO,_U,		L_FUUDA,    R_DAROU,
@@ -584,12 +584,12 @@ static	Uchar	fzk_hu[] = {
 0xff
 };
 
-static	Uchar	fzk_he[] = {
+static	u_char	fzk_he[] = {
 (0<<5)+0,			L_HE,       R_HE,
 0xff
 };
 
-static	Uchar	fzk_be[] = {
+static	u_char	fzk_be[] = {
 (0<<5) + 2,	_KA,_RA,	L_BESI,     R_BEKARA,
 (0<<5) + 1,	_KI,		L_BESI,     R_BEKI,
 (0<<5) + 1,	_KU,		L_BESI,     R_BEKU,
@@ -597,14 +597,14 @@ static	Uchar	fzk_be[] = {
 0xff
 };
 
-static	Uchar	fzk_ho[] = {
+static	u_char	fzk_ho[] = {
 (0<<5) + 1,	_U,		L_HOU,      R_HOU,
 (0<<5) + 1,	_KA,		L_HOKA,     R_HOKA,
 (0<<5) + 1,	_DO,		L_HODO,     R_HODO,
 0xff
 };
 
-static	Uchar	fzk_ma[] = {
+static	u_char	fzk_ma[] = {
 (0<<5) + 1,	_I,		L_MAI,      R_MAI,
 (0<<5) + 1,	_SI,		L_MASU,     R_DESHI,
 (1<<5) + 0,			L_MASU,	    R_MEIREI2,
@@ -620,7 +620,7 @@ static	Uchar	fzk_ma[] = {
 0xff
 };
 
-static	Uchar	fzk_mi[] = {
+static	u_char	fzk_mi[] = {
 (0<<5) + 0,			L_YOUGEN,   R_MI,
 (0<<5) + 2,	_TA,_I,		L_MITAIDA,  R_MITAI,
 (2<<5) + 1,	_DA,		L_MITAIDA,  R_MITAIDA,
@@ -641,7 +641,7 @@ static	Uchar	fzk_mi[] = {
 0xff
 };
 
-static	Uchar	fzk_mo[] = {
+static	u_char	fzk_mo[] = {
 (0<<5) + 0,			L_MO1,      R_MO1,
 (0<<5) + 0,			L_MO2,	    R_MO2,
 (0<<5) + 2,	_XTU,_TE,	L_MOTTE,    R_MOTTE,
@@ -657,7 +657,7 @@ static	Uchar	fzk_mo[] = {
 0xff
 };
 
-static	Uchar	fzk_ya[] = {
+static	u_char	fzk_ya[] = {
 (0<<5) + 0,			L_YA1,      R_YA1,
 (0<<5) + 0,			L_YA2,      R_YA2,
 (0<<5) + 2,	_SU,_I,		L_YASUI,    R_KSHUUSI,
@@ -676,12 +676,12 @@ static	Uchar	fzk_ya[] = {
 0xff
 };
 
-static	Uchar	fzk_yu[] = {
+static	u_char	fzk_yu[] = {
 (0<<5) + 1,	_E,		L_YUE,      R_YUE,
 0xff
 };
 
-static	Uchar	fzk_yo[] = {
+static	u_char	fzk_yo[] = {
 (0<<5) + 0,			L_YO,	    R_SHUUJO,
 (0<<5) + 1,	_I,		L_YOI,      R_KSHUUSI,
 (0<<5) + 1,	_U,		L_YOU,      R_YOU1,
@@ -714,7 +714,7 @@ static	Uchar	fzk_yo[] = {
 0xff
 };
 
-static	Uchar	fzk_ra[] = {
+static	u_char	fzk_ra[] = {
 (0<<5) + 2,	_SI,_I,		L_RASII,    R_RASII,
 (1<<5) + 2,	_KA,_XTU,	L_RASII,    R_ONBIN1,
 (1<<5) + 1,	_KI,		L_RASII,    R_GOTOKI,
@@ -728,7 +728,7 @@ static	Uchar	fzk_ra[] = {
 0xff
 };
 
-static	Uchar	fzk_re[] = {
+static	u_char	fzk_re[] = {
 (0<<5) + 0,			L_RERU,	    R_RARE,
 (0<<5) + 1,	_YO,		L_RERU,     R_MEIREI2,
 (0<<5) + 1,	_RU,		L_RERU,     R_SHUUSI,
@@ -737,7 +737,7 @@ static	Uchar	fzk_re[] = {
 0xff
 };
 
-static	Uchar	fzk_wa[] = {
+static	u_char	fzk_wa[] = {
 (0<<5) + 0,			L_WA,	    R_SHUUJO,
 (0<<5) + 1,	_KE,		L_WAKE,     R_WAKE,
 (0<<5) + 1,	_NE,		L_WANE,     R_SHUUJO,
@@ -745,7 +745,7 @@ static	Uchar	fzk_wa[] = {
 0xff
 };
 
-static	Uchar	fzk_nn[] = {
+static	u_char	fzk_nn[] = {
 (0<<5) + 0,			L_NN1,      R_NN1,
 (0<<5) + 0,			L_NN2,      R_NN2,
 0xff
@@ -753,7 +753,7 @@ static	Uchar	fzk_nn[] = {
 
 
 
-Uchar	*fzkadr[] = {
+u_char	*fzkadr[] = {
 	0,	fzk_a,	0,	fzk_i,	0,
 	fzk_u,	0,	fzk_e,	0,	fzk_o,
 	fzk_ka,	fzk_ga,	fzk_ki,	0,	fzk_ku,

--- a/getrank.c
+++ b/getrank.c
@@ -62,7 +62,7 @@ setstynum (void)
 {
 	KHREC	*kptr;
 	STDYIN	*sptr;
-	Int	count;
+	int	count;
 
 	for (kptr = kouhotbl, count = khcount ; count-- ; kptr++) { 
 		sptr = srchstdy(kptr -> clrec -> jnode -> jseg, kptr -> offs,
@@ -78,7 +78,7 @@ static	void
 setnspr (KHREC *kptr, STDYIN *sptr)
 {
 	KHREC		*ptr;
-	Int		keepnm;
+	int		keepnm;
 	TypeStyNum	styno;
 
 	styno = kptr -> styno = sptr -> styno;
@@ -112,7 +112,7 @@ setnspr (KHREC *kptr, STDYIN *sptr)
 		}
 	}
 
-	kptr -> rank = (Uchar)keepnm;
+	kptr -> rank = (u_char)keepnm;
 	trank++;
 	if (keepnm <= nrank) nrank++;
 	if (sptr -> nmflg && (nrank > keepnm)) nrank = keepnm;
@@ -124,8 +124,8 @@ static	void
 regetrank (void)
 {
 	KHREC	*kptr;		
-	Int	count;
-	Int	tmp;
+	int	count;
+	int	tmp;
 
 	if (nrank < trank) {
 		tmp = nrank;
@@ -138,12 +138,12 @@ regetrank (void)
 	for (count = khcount, kptr = kouhotbl ; count-- ; kptr++) {
 		if (!(kptr -> rank)) {
 			if (tmp && kptr -> mode && !(kptr -> offs)) {
-				kptr -> rank = (Uchar)tmp++;
+				kptr -> rank = (u_char)tmp++;
 			}
 			else
-				kptr -> rank = (Uchar)trank++;
+				kptr -> rank = (u_char)trank++;
 		}
-		else if ((Short)kptr -> rank >= nrank)
-			kptr -> rank += (Uchar)nkhcount;
+		else if ((short)kptr -> rank >= nrank)
+			kptr -> rank += (u_char)nkhcount;
 	}
 }

--- a/hzstrlen.c
+++ b/hzstrlen.c
@@ -43,8 +43,8 @@
 #include "sj_dict.h"
 #include "kanakan.h"
 
-Int
-euc_codesize (Uchar c)
+int
+euc_codesize (u_char c)
 {
 	if ((c & KanjiModeMask) == 0x90) {
 		return 1;
@@ -57,10 +57,10 @@ euc_codesize (Uchar c)
 	}
 }
 
-Int
-hzstrlen (Uchar *ptr, Int len)
+int
+hzstrlen (u_char *ptr, int len)
 {
-	Uchar	*head;
+	u_char	*head;
 	head = ptr;
 	while (len-- > 0) ptr += euc_codesize(*ptr);
 	return (ptr - head);

--- a/init.c
+++ b/init.c
@@ -37,11 +37,11 @@
 
 #include "sj_kcnv.h"
 
-Void	seg_count(dict)
+void	seg_count(dict)
 DICT	*dict;
 {
-	Uchar	*p;
-	Uchar	*q;
+	u_char	*p;
+	u_char	*q;
 	TypeDicSeg	segcnt = 0;
 
 	if (dict-> getidx) {
@@ -58,10 +58,10 @@ DICT	*dict;
 	dict->segunit = (segcnt == 0) ? 1 : segcnt;
 }
 
-Void	mkidxtbl(dict)
+void	mkidxtbl(dict)
 DICT	*dict;
 {
-	Uchar	*p;
+	u_char	*p;
 	TypeDicSeg	seg;
 
 	if (!dict->getidx || !dict->getofs) return;
@@ -78,7 +78,7 @@ DICT	*dict;
 	}
 }
 
-Void	initwork()
+void	initwork()
 {
 	jrt1st = jrt2nd = maxjptr = (JREC *)0;
 	clt1st = clt2nd = maxclptr = (CLREC *)0;

--- a/istrcmp.c
+++ b/istrcmp.c
@@ -33,8 +33,8 @@
 #include "const.h"
 #include "sj_typedef.h"
 
-Int
-istrcmp(Uchar *yomip, Uchar *idxp, Int ylen, Int ilen)
+int
+istrcmp(u_char *yomip, u_char *idxp, int ylen, int ilen)
 {
 	while (1) {
 		if ((ilen | ylen) == 0)

--- a/memory2.c
+++ b/memory2.c
@@ -37,7 +37,7 @@
 
 #include "sj_kcnv.h"
 
-Void	free_jrec(), free_clrec();
+void	free_jrec(), free_clrec();
 
 JREC	*free_jlst(p)
 JREC	*p;
@@ -72,12 +72,12 @@ JREC	*p;
 
 CLREC	*free_clst(p, l)
 CLREC	*p;
-Int	l;
+int	l;
 {
 	CLREC	*cpk;
 	CLREC	*cp;
 	CLREC	*cn;
-	Int	i = FALSE;
+	int	i = FALSE;
 
 	cp = cpk = NULL;
 
@@ -85,7 +85,7 @@ Int	l;
 
 		cn = p -> clsort;
 
-		if ((Int)p -> cllen == l) {
+		if ((int)p -> cllen == l) {
 			if (p == selcl) {
 				if (cp) {
 					p -> clsort = cpk;
@@ -115,7 +115,7 @@ Int	l;
 	return cpk;
 }
 
-Void	free_clall(p)
+void	free_clall(p)
 CLREC	*p;
 {
 	CLREC	*next;
@@ -128,7 +128,7 @@ CLREC	*p;
 	}
 }
 
-Void	free_jall(p)
+void	free_jall(p)
 JREC	*p;
 {
 	JREC	*next;
@@ -140,7 +140,7 @@ JREC	*p;
 	}
 }
 
-Void	freework()
+void	freework()
 {
 	free_clall(maxclptr);
 	clt1st = maxclptr = NULL;

--- a/mk2claus.c
+++ b/mk2claus.c
@@ -38,11 +38,11 @@
 #include "sj_kcnv.h"
 #include "sj_right.h"
 
-Int	terminate(), priority();
-Void	mkjiritu(), mkbunsetu(), wakachi(), pritiny();
-Void	free_clall(), free_jall();
+int	terminate(), priority();
+void	mkjiritu(), mkbunsetu(), wakachi(), pritiny();
+void	free_clall(), free_jall();
 
-Static	Int	set2nd(clrec)
+Static	int	set2nd(clrec)
 CLREC	*clrec;
 {
 
@@ -65,17 +65,17 @@ CLREC	*clrec;
 	return rec2 ? (clrec -> cllen + rec2 -> cllen) : (clrec -> cllen);
 }
 
-Void	mk2claus()
+void	mk2claus()
 {
-	Uchar	*keepptr;
-	Int	keeplen;
+	u_char	*keepptr;
+	int	keeplen;
 	CLREC	*clrec;
-	Int	len;
-	Int	save2ln;
-	Int	prty;
-	Int	maxprty;
-	Int	count;
-	Int	prty2;
+	int	len;
+	int	save2ln;
+	int	prty;
+	int	maxprty;
+	int	count;
+	int	prty2;
 
 	prty = maxprty = prty2 = 0;
 
@@ -117,9 +117,9 @@ Void	mk2claus()
 		}
 
 		if (Termtbl[clrec -> right] & T_SHUUJO)
-			clrec -> cl2len = (Uchar)len;
+			clrec -> cl2len = (u_char)len;
 		else
-			clrec -> cl2len = (Uchar)save2ln;
+			clrec -> cl2len = (u_char)save2ln;
 
 		if (selcl -> cl2len > clrec -> cl2len) continue;
 

--- a/mkbunset.c
+++ b/mkbunset.c
@@ -42,8 +42,8 @@
 #include "sj_hinsi.h"
 #include "kanakan.h"
 
-Int	terminate();
-Void	setclrec(), srchfzk();
+int	terminate();
+void	setclrec(), srchfzk();
 
 void
 mkbunsetu(void)

--- a/mkjiritu.c
+++ b/mkjiritu.c
@@ -41,7 +41,7 @@
 #include "sj_kcnv.h"
 #include "kanakan.h"
 
-Int	srchhead();
+int	srchhead();
 
 static void dic_mu(int mode);
 static void dic_cl(void);
@@ -176,7 +176,7 @@ dic_cl(void)
 
 	if (!StudyExist()) return;
 
-	if ((pos = ClStudyIdx[(Short) *cnvstart / ClStudyStep]) != (u_short)-1) {
+	if ((pos = ClStudyIdx[(short) *cnvstart / ClStudyStep]) != (u_short)-1) {
 
 		for (p = ClStudyDict + pos ; !iseocl(p) ; p = ClNextTag(p)) {
 			cmp = strncmp(cnvstart, (u_char*)ClYomiPos(p),

--- a/mvmemd.c
+++ b/mvmemd.c
@@ -38,10 +38,10 @@
 #include "sj_rename.h"
 #include "sj_typedef.h"
 
-Void	mvmemd(src, dest, len)
-Uchar	*src;
-Uchar	*dest;
-Int	len;
+void	mvmemd(src, dest, len)
+u_char	*src;
+u_char	*dest;
+int	len;
 {
 	while (len-- > 0) *(--dest) = *(--src);
 }

--- a/mvmemi.c
+++ b/mvmemi.c
@@ -38,10 +38,10 @@
 #include "sj_rename.h"
 #include "sj_typedef.h"
 
-Void	mvmemi(src, dest, len)
-Uchar	*src;
-Uchar	*dest;
-Int	len;
+void	mvmemi(src, dest, len)
+u_char	*src;
+u_char	*dest;
+int	len;
 {
 	while (len-- > 0) *dest++ = *src++;
 }

--- a/peepdic.c
+++ b/peepdic.c
@@ -41,26 +41,26 @@
 #include "kanakan.h"
 
 
-Uchar	*skiphblk();
+u_char	*skiphblk();
 
 static	void	add_yomi (void);
-static	void	cd2sjh_chr (Uchar ch, Uchar *dst);
-static	Int	next_douon (void);
-static	Int	next_hinsi (void);
-static	Int	next_kanji (void);
-static	Int	prev_douon (void);
-static	Int	prev_hinsi (void);
-static	Int	prev_kanji (void);
-static	void	set_buf (Uchar *buf);
+static	void	cd2sjh_chr (u_char ch, u_char *dst);
+static	int	next_douon (void);
+static	int	next_hinsi (void);
+static	int	next_kanji (void);
+static	int	prev_douon (void);
+static	int	prev_hinsi (void);
+static	int	prev_kanji (void);
+static	void	set_buf (u_char *buf);
 static	void	set_idxyomi (void);
 static	void	set_kanji (void);
 
 
 
-Int
-getusr (Uchar *buf)
+int
+getusr (u_char *buf)
 {
-	Int nlen;
+	int nlen;
 
 	peepyomi[0] = peepknj[0] = peepgrm = 0;
 
@@ -89,8 +89,8 @@ getusr (Uchar *buf)
 
 
 
-Int
-nextusr (Uchar *buf)
+int
+nextusr (u_char *buf)
 {
 	(*curdict->getdic)(curdict, peepidx);
 	get_askknj();
@@ -106,8 +106,8 @@ nextusr (Uchar *buf)
 
 
 
-Int
-prevusr (Uchar *buf)
+int
+prevusr (u_char *buf)
 {
 	(*curdict->getdic)(curdict, peepidx);
 	get_askknj();
@@ -126,7 +126,7 @@ prevusr (Uchar *buf)
 static	void
 set_kanji (void)
 {
-	Int	len;
+	int	len;
 
 	len = getkanji(peepyomi, getnlen(peepdptr) + getplen(peepdptr),
 			peepkptr, peepknj);
@@ -136,10 +136,10 @@ set_kanji (void)
 
 
 static	void
-set_buf (Uchar *buf)
+set_buf (u_char *buf)
 {
-	Uchar	*p;
-	Int      i, csize;
+	u_char	*p;
+	int      i, csize;
 
 	for (p = peepyomi ; *p ; ) *buf++ = *p++;
 	*buf++ = 0;
@@ -156,11 +156,11 @@ set_buf (Uchar *buf)
 
 
 
-static	Int
+static	int
 prev_kanji (void)
 {
-	Uchar	*p1;
-	Uchar	*p2;
+	u_char	*p1;
+	u_char	*p2;
 
 	p1 = peephptr + 1;
 	if (peepkptr <= p1) return prev_hinsi();
@@ -176,12 +176,12 @@ prev_kanji (void)
 
 
 
-static	Int
+static	int
 prev_hinsi (void)
 {
-	Uchar	*p1;
-	Uchar	*p2;
-	Int     nlen;
+	u_char	*p1;
+	u_char	*p2;
+	int     nlen;
 
 	nlen = getnlen(peepdptr);
         p1 = peepdptr + DouonBlkSizeNumber + nlen;
@@ -207,12 +207,12 @@ prev_hinsi (void)
 
 
 
-static	Int
+static	int
 prev_douon (void)
 {
-	Uchar	*p1;
-	Uchar	*p2;
-	Int     nlen;
+	u_char	*p1;
+	u_char	*p2;
+	int     nlen;
 
 	if (peepdptr <= segtop()) {
 		if (peepidx <= DicSegBase) return 0;
@@ -263,10 +263,10 @@ prev_douon (void)
 
 
 
-static	Int
+static	int
 next_kanji (void)
 {
-	Uchar	*p1;
+	u_char	*p1;
 
 	p1 = skipkstr(peepkptr);
 	if (*p1 == HinsiBlkTerm) return next_hinsi();
@@ -276,10 +276,10 @@ next_kanji (void)
 
 
 
-static	Int
+static	int
 next_hinsi (void)
 {
-	Uchar	*p1;
+	u_char	*p1;
 
 	p1 = skiphblk(peephptr);
 	if (p1 >= getntag(peepdptr)) return next_douon();
@@ -291,11 +291,11 @@ next_hinsi (void)
 
 
 
-static	Int
+static	int
 next_douon (void)
 {
-	Uchar	*p1;
-        Int      nlen;
+	u_char	*p1;
+        int      nlen;
 
 	p1 = getntag(peepdptr);
 
@@ -331,7 +331,7 @@ next_douon (void)
 static	void
 set_idxyomi (void)
 {
-	Uchar	*p1, *p2;
+	u_char	*p1, *p2;
 
 	if ((p2 = get_idxptr(peepidx)) != NULL) {
 		p1 = peepyomi;
@@ -348,8 +348,8 @@ set_idxyomi (void)
 static	void
 add_yomi (void)
 {
-	Int	nlen;
-	Uchar	*p1, *p2;
+	int	nlen;
+	u_char	*p1, *p2;
 
 	nlen = getnlen(peepdptr);
 	p1 = peepyomi + getplen(peepdptr) * 2;
@@ -366,7 +366,7 @@ add_yomi (void)
 
 
 static	void
-cd2sjh_chr (Uchar ch, Uchar *dst)
+cd2sjh_chr (u_char ch, u_char *dst)
 {
 	if (ch == _TYOUON) {			
 		*dst++ = 0xa1;

--- a/ph2knj.c
+++ b/ph2knj.c
@@ -42,21 +42,21 @@
 #include "kanakan.h"
 
 
-Int	sj2cd_chr();
+int	sj2cd_chr();
 void	mk2claus();
-Void	freework();
-Void    selclrec();
+void	freework();
+void    selclrec();
 CLREC	*free_clst();
 JREC	*free_jlst();
 
 
 
-Int	ph2knj
-(Uchar *zyomi, Uchar *kanji, Int knjlen)
+int	ph2knj
+(u_char *zyomi, u_char *kanji, int knjlen)
 {
-	Uchar	*ptr;
-	Uchar	*dst;
-	Int	i;
+	u_char	*ptr;
+	u_char	*dst;
+	int	i;
 
 	for (ptr = zyomi, dst = hyomi, i = 0 ; *ptr ; ) {
 		if (i++ >= MaxPhInputLen) { *kanji = 0; return 0; }
@@ -94,7 +94,7 @@ Int	ph2knj
 		prevclgrm = selcl -> jnode -> hinsi;
 		prevclrow = selcl -> right;
 
-                clt1st = free_clst(clt1st, (Int)selcl -> cllen);
+                clt1st = free_clst(clt1st, (int)selcl -> cllen);
                 jrt1st = free_jlst(jrt1st);
 
 		cnvstart += selcl -> cllen;

--- a/ph_khtbl.c
+++ b/ph_khtbl.c
@@ -46,7 +46,7 @@ ph_setsty (CLREC *clrec)
 {
 	JREC		*jrec;
 	TypeDicOfs	offset;
-	Uchar		*ptr;
+	u_char		*ptr;
 	STDYIN		*sptr;
 
 	if (!seldict((jrec = clrec -> jnode) -> dicid)) {
@@ -83,11 +83,11 @@ ph_setsty (CLREC *clrec)
 
 
 
-Int
+int
 ph_khtbl (CLREC *clrec)
 {
 	JREC	*jrec;
-	Int	flg = FALSE;
+	int	flg = FALSE;
 
 	switch((jrec = clrec -> jnode) -> class) {
 	case C_DICT:

--- a/priority.c
+++ b/priority.c
@@ -40,7 +40,7 @@
 #include "sj_right.h"
 #include "sj_prty.h"
 
-Static	Int	isfukusi(hinsi)
+Static	int	isfukusi(hinsi)
 TypeGram	hinsi;
 {
 	if (FUKUSI_1 <= hinsi && hinsi <= FUKUSI_7)
@@ -50,7 +50,7 @@ TypeGram	hinsi;
 	return FALSE;
 }
 
-Static	Int	istaigen(right)
+Static	int	istaigen(right)
 TypeCnct	right;
 {
 	if (right == R_MEISI || right == R_DMEISI || right == R_SMEISI1)
@@ -62,7 +62,7 @@ TypeCnct	right;
 	return FALSE;
 }
 
-Static	Int	taicnt(hinsi1, hinsi2)
+Static	int	taicnt(hinsi1, hinsi2)
 TypeGram	hinsi1;
 TypeGram	hinsi2;
 {
@@ -91,7 +91,7 @@ TypeGram	hinsi2;
 	}
 }
 
-Static	Int	sttcnt(hinsi1, hinsi2)
+Static	int	sttcnt(hinsi1, hinsi2)
 TypeGram	hinsi1;
 TypeGram	hinsi2;
 {
@@ -102,15 +102,15 @@ TypeGram	hinsi2;
 	return 4;
 }
 
-Int	priority(clrec)
+int	priority(clrec)
 CLREC	*clrec;
 {
 	int		prty;
 	CLREC		*cl2rec;
-	Int		keeplen;
+	int		keeplen;
 	TypeGram	hinsi1;
-	Int		i;
-	Int		prev = 0;
+	int		i;
+	int		prev = 0;
 
 	if (clrec->cllen == clrec->cl2len) return 0xff;
 
@@ -155,7 +155,7 @@ CLREC	*clrec;
 
 	if (clrec->right == R_WO  || clrec->right == R_WO_S ||
 	    clrec->right == R_NI1 || clrec->right == R_DRENYOU2) {
-		while (cl2rec && (Int)cl2rec->cllen == keeplen) {
+		while (cl2rec && (int)cl2rec->cllen == keeplen) {
 			if (cl2rec->kubun == K_DOUSHI) {
 				prty = 14;
 				goto finish;
@@ -166,7 +166,7 @@ CLREC	*clrec;
 
 	else if (clrec->right == R_SETTOU) {
 		prty = 0;
-		while (cl2rec && (Int)cl2rec -> cllen == keeplen) {
+		while (cl2rec && (int)cl2rec -> cllen == keeplen) {
 			if (cl2rec -> jnode -> sttofs )
 				i = 2;
 			else
@@ -181,7 +181,7 @@ CLREC	*clrec;
 
 	else if (istaigen(clrec->right)) {
 		prty = 0;
-		while (cl2rec && (Int)cl2rec->cllen == keeplen) {
+		while (cl2rec && (int)cl2rec->cllen == keeplen) {
 			i = taicnt(hinsi1, cl2rec->jnode->hinsi);
 			if (i > prty)
 				prty = i;
@@ -198,7 +198,7 @@ CLREC	*clrec;
 
 
 	if (prty & RENTAI) {
-		while (cl2rec && (Int)cl2rec->cllen == keeplen) {
+		while (cl2rec && (int)cl2rec->cllen == keeplen) {
 			if (cl2rec -> kubun == K_TAIGEN) {
 				prty &= GETPRI;
 				goto finish;
@@ -213,7 +213,7 @@ CLREC	*clrec;
 
 		if (prty == P_RENYOU_J || prty == P_RENYOU_M ) {
 			while (clrec->cllen != 1 && cl2rec &&
-			       (Int)cl2rec->cllen == keeplen ) {
+			       (int)cl2rec->cllen == keeplen ) {
 				if (cl2rec->kubun == K_DOUSHI) {
 					prty = 6;
 					goto finish;
@@ -251,17 +251,17 @@ finish:
 }
 
 
-Void	pritiny()
+void	pritiny()
 {
 	CLREC	*clrec;
-	Int	keeplen;
+	int	keeplen;
 	int	i, prty = 0;
 
 	clrec = selcl;
 	keeplen = clrec -> cllen;
 
 	if (istaigen(prevclrow)) {
-		while (clrec && (Int)clrec -> cllen == keeplen) {
+		while (clrec && (int)clrec -> cllen == keeplen) {
 			i = taicnt(prevclgrm, clrec -> jnode -> hinsi);
 			if (i > prty) {
 				selcl = clrec;
@@ -273,7 +273,7 @@ Void	pritiny()
 
 	else {
 
-		while (clrec && (Int)clrec -> cllen == keeplen) {
+		while (clrec && (int)clrec -> cllen == keeplen) {
 			if (clrec -> jnode -> hinsi >= MYOUJI &&
 			    clrec -> jnode -> hinsi <= KEN_KU)
 				clrec = clrec -> clsort;

--- a/prtytbl.c
+++ b/prtytbl.c
@@ -38,7 +38,7 @@
 #include "sj_rename.h"
 #include "sj_typedef.h"
 
-Uchar	taipri[7][45] = {
+u_char	taipri[7][45] = {
 
 	{ 0,  4,  4,  4,  4,  4,  4,  4,  4,  4,
 		  4,  4,  3,  3,  3,  3,  3,  3,  0,  0,
@@ -78,7 +78,7 @@ Uchar	taipri[7][45] = {
 
 
 
-Uchar	sttpri[5][31] = {
+u_char	sttpri[5][31] = {
 
 	{ 0,  7,  7,  7,  7,  7,  7,  7,  7,  7,
 		  7,  7,  2,  4,  4,  4,  4,  4,  0,  0,

--- a/s2ctbl.c
+++ b/s2ctbl.c
@@ -39,7 +39,7 @@
 #include "sj_typedef.h"
 #include "sj_yomi.h"
 
-Uchar	kigou[] = {
+u_char	kigou[] = {
 		Y_L_KAKKO,
 		Y_KUTEN,
 		Y_TOUTEN,

--- a/selclrec.c
+++ b/selclrec.c
@@ -41,14 +41,14 @@
 
 
 
-Void	free_clall(), free_jall(), mkjiritu(), mkbunsetu();
-Void	wakachi();
+void	free_clall(), free_jall(), mkjiritu(), mkbunsetu();
+void	wakachi();
 
 
 
-Void	selclrec()
+void	selclrec()
 {
-	Int	len;
+	int	len;
 	CLREC	*rec;
 
 	
@@ -96,8 +96,8 @@ Void	selclrec()
 
 	
 	if (rec == NULL) {
-		Int	klen;
-		Uchar	ch;
+		int	klen;
+		u_char	ch;
 
 		
 		free_clall(clt1st);

--- a/selsuuji.c
+++ b/selsuuji.c
@@ -32,7 +32,7 @@
 #include "const.h"
 #include "sj_suuji.h"
 
-static	Ushort	selsjAR[] = {
+static	u_short	selsjAR[] = {
 	SelArb0,
 	SelArbCma	| JFLAG_NK4 | JFLAG_NN0,
 	SelKanSjYm	| JFLAG_NN0,
@@ -41,7 +41,7 @@ static	Ushort	selsjAR[] = {
 	SelNumTerm
 };
 
-static	Ushort	selsjARCM[] = {
+static	u_short	selsjARCM[] = {
 	SelArbCma	| JFLAG_NK4 | JFLAG_NN0,
 	SelArb0,
 	SelKanSjYm	| JFLAG_NN0,
@@ -50,7 +50,7 @@ static	Ushort	selsjARCM[] = {
 	SelNumTerm
 };
 
-static	Ushort	selsjKAZU[] = {
+static	u_short	selsjKAZU[] = {
 	SelKanSjYm	| JFLAG_NN0,
 	SelKanSjYm2	| SelNum1_23_10_1 | JFLAG_NN0,
 	SelKanSj0	| JFLAG_NK2,
@@ -59,49 +59,49 @@ static	Ushort	selsjKAZU[] = {
 	SelNumTerm
 };
 
-static	Ushort	selsjSUUJI[] = {
+static	u_short	selsjSUUJI[] = {
 	SelKanSj0,
 	SelArb0,
 	SelNumTerm
 };
 
-static	Ushort	selsjNANSUU[] = {
+static	u_short	selsjNANSUU[] = {
 	SelKanSjYm,
 	SelNumTerm
 };
 
-static	Ushort	selsjAR17[] = {
+static	u_short	selsjAR17[] = {
 	SelLongArb,
 	SelLongArbCma,
 	SelNumTerm
 };
 
-static	Ushort	selsjAR17CM[] = {
+static	u_short	selsjAR17CM[] = {
 	SelLongArbCma,
 	SelLongArb,
 	SelNumTerm
 };
 
-static	Ushort	selsjAR17SJ[] = {
+static	u_short	selsjAR17SJ[] = {
 	SelLongArb,
 	SelLongSj,
 	SelNumTerm
 };
 
-static	Ushort	selsjKANKURA[] = {
+static	u_short	selsjKANKURA[] = {
 	SelKanSjKr,
 	SelArbKr,
 	SelNumTerm
 };
 
-static	Ushort	selsjARAKURA[] = {
+static	u_short	selsjARAKURA[] = {
 	SelArbKr,
 	SelKanSjKr	| JFLAG_NSN,
 	SelNumTerm
 };
 
 
-Ushort	*selsjadrs[] = {
+u_short	*selsjadrs[] = {
 		selsjAR,
 		selsjARCM,
 			selsjKAZU,

--- a/setconj.c
+++ b/setconj.c
@@ -42,11 +42,11 @@
 #include "sj_yomi.h"
 #include "kanakan.h"
 
-static	Int
-cnjstrcmp (Uchar *yptr, Uchar *cnjp, Int *saml)
+static	int
+cnjstrcmp (u_char *yptr, u_char *cnjp, int *saml)
 {
-	Int	asklen;
-	Int	nkrlen;
+	int	asklen;
+	int	nkrlen;
 
 	asklen = CnjAskLen(cnjp);
 
@@ -82,7 +82,7 @@ static	TypeCnct
 cnvrow (JREC *rec, TypeCnct row)
 {
 	TypeGram	hinsi;
-	Int		stt;
+	int		stt;
 
 	hinsi = rec -> hinsi;
 
@@ -111,16 +111,16 @@ cnvrow (JREC *rec, TypeCnct row)
 	return row;
 }
 
-Int
+int
 setconj (TypeGram hinsi, JREC *jrec, CREC *crec)
 {
-	Uchar	*yptr;
-	Int	cmp;
+	u_char	*yptr;
+	int	cmp;
 	TypeCnct	right;
-	Int	saml;
-	Int	ofslen;
+	int	saml;
+	int	ofslen;
 	int	count = 0;
-	Uchar	*cnj;
+	u_char	*cnj;
 
 	if ((cnj  = Conjadr(hinsi)) != NULL) {
 		saml = ofslen = 0;
@@ -146,7 +146,7 @@ setconj (TypeGram hinsi, JREC *jrec, CREC *crec)
 			if (isdpnd(*(yptr + saml))) continue;
 
 			if ((right = cnvrow(jrec, (TypeCnct)CnjRight(cnj))) != '\0') {
-				crec -> len   = (Uchar)(ofslen + saml);
+				crec -> len   = (u_char)(ofslen + saml);
 				crec -> right = right;
 				count++;
 				crec++;

--- a/setkouho.c
+++ b/setkouho.c
@@ -49,7 +49,7 @@ setkouho(CLREC* clrec, TypeDicOfs offs, int mode)
 {
 	JREC	*jrec;
 	KHREC	*kptr;		
-	u_char	TFar	*fptr;
+	u_char	*fptr;
 	int	flg;
 	int	i;
 
@@ -140,7 +140,7 @@ void
 ph_setkouho(CLREC* clrec, TypeDicOfs offs, STDYIN* sptr)
 {
 	JREC	*jrec;
-	u_char	TFar	*p;
+	u_char	*p;
 
 	
 	if (sptr) {

--- a/setubi.c
+++ b/setubi.c
@@ -41,7 +41,7 @@
 #include "sj_hinsi.h"
 #include "kanakan.h"
 
-Uchar*
+u_char*
 getstb(TypeGram hinsi)
 {
 	if (hinsi < MEISI_1 || hinsi > TIMEI) return NULL;
@@ -51,14 +51,14 @@ getstb(TypeGram hinsi)
 
 
 void
-setubi(JREC *rec, Uchar *stbtbl)
+setubi(JREC *rec, u_char *stbtbl)
 {
-	Uchar	*stb;
-	Uchar	*yptr;
-	Uchar	*sptr;
-	Int	slen;
+	u_char	*stb;
+	u_char	*yptr;
+	u_char	*sptr;
+	int	slen;
 	JREC	*new;
-	Int	cmp;
+	int	cmp;
 
 	stb = stbtbl--;
 
@@ -75,9 +75,9 @@ setubi(JREC *rec, Uchar *stbtbl)
 
 		if ((cmp != MATCH) || isdpnd(*(yptr + slen))) continue;
 
-		if (!(new = argjrec((Int)(rec -> jlen + slen), rec))) continue;
+		if (!(new = argjrec((int)(rec -> jlen + slen), rec))) continue;
 
-		new -> stbofs = (Uchar)(stb - stbtbl);
+		new -> stbofs = (u_char)(stb - stbtbl);
 		new -> flags  |= StbBakeru(stb) ? JFLAG_KA : 0;
 	}
 }

--- a/sj2code.c
+++ b/sj2code.c
@@ -40,11 +40,11 @@
 #include "sj_kcnv.h"
 #include "sj_yomi.h"
 
-Int	sj2cd_chr(euc, yomi)
-Uchar	*euc;			
-Uchar	*yomi;
+int	sj2cd_chr(euc, yomi)
+u_char	*euc;
+u_char	*yomi;
 {
-	Uchar	chr;
+	u_char	chr;
 
 	if ((chr = *euc++) == EUC_a1) {
 		chr = *euc;
@@ -117,10 +117,10 @@ Uchar	*yomi;
 
 
 
-Int	sj2cd_str(euc, yomi, len)
-Uchar	*euc;
-Uchar	*yomi;
-Int	len;
+int	sj2cd_str(euc, yomi, len)
+u_char	*euc;
+u_char	*yomi;
+int	len;
 {
 	
 	if (!len--) return FALSE;

--- a/sj_dict.h
+++ b/sj_dict.h
@@ -87,7 +87,7 @@
 
 
 
-#define getsize(p)	(((Int)(*(p) & 0x0f) * 0x100) + *((p) + 1))
+#define getsize(p)	(((int)(*(p) & 0x0f) * 0x100) + *((p) + 1))
 
 
 

--- a/sj_study.h
+++ b/sj_study.h
@@ -85,7 +85,7 @@
 
 
 
-#define	iseocl(p)	( !ClYomiLen(p) || (Uchar *)(p) >= ClStudyTail )
+#define	iseocl(p)	( !ClYomiLen(p) || (u_char *)(p) >= ClStudyTail )
 
 
 
@@ -104,7 +104,7 @@
 #define	ClHighNum(p)	*(p + CL_NUMH)
 #define	ClLowNum(p)	*(p + CL_NUML)
 #define	ClGetNum(p)	(ClHighNum(p) * 0x100 + ClLowNum(p))
-#define	ClSetNum(p, n)	(ClHighNum(p)=(Uchar)((n) >> 8), ClLowNum(p)=(Uchar)(n))
+#define	ClSetNum(p, n)	(ClHighNum(p)=(u_char)((n) >> 8), ClLowNum(p)=(u_char)(n))
 
 
 

--- a/sj_typedef.h
+++ b/sj_typedef.h
@@ -39,22 +39,6 @@
 #ifndef	_SJ_TYPEDEF
 #define	_SJ_TYPEDEF  1
 
-#define	RECURS
-
-#define	TFar
-#define	Far
-
-#define	Void	void
-#define	Char	char
-#define	Uchar	unsigned char
-#define	Short	short
-#define	Ushort	unsigned short
-#define	Int	int
-#define	Uint	unsigned int
-#define	Long	long
-#define	Ulong	unsigned long
-
-
 #include <sys/types.h>
 
 typedef	u_char	TypeGroup;

--- a/skiphblk.c
+++ b/skiphblk.c
@@ -39,10 +39,10 @@
 #include "sj_typedef.h"
 #include "sj_dict.h"
 
-Uchar	*skipkstr();
+u_char	*skipkstr();
 
-Uchar	*skiphblk(ptr)
-Uchar	*ptr;
+u_char	*skiphblk(ptr)
+u_char	*ptr;
 {
 	ptr++;
 

--- a/srchdict.c
+++ b/srchdict.c
@@ -99,7 +99,7 @@ srchdict(u_char* tagp)
 	while ((int)dicinl <= maxlen) {
 
 
-		segno = srchidx(prevseg, (Int)dicinl);
+		segno = srchidx(prevseg, (int)dicinl);
 
 		(*curdict->getdic)(curdict, segno);
 

--- a/srchhead.c
+++ b/srchhead.c
@@ -38,7 +38,7 @@
 #include "sj_kcnv.h"
 #include "sj_yomi.h"
 
-Int	srchhead()
+int	srchhead()
 {
 	if (*cnvstart == _O) {
 		headcode = SETTOU_O;

--- a/srchidx.c
+++ b/srchidx.c
@@ -41,7 +41,7 @@
 #include "sj_kcnv.h"
 #include "kanakan.h"
 
-Int	istrcmp();
+int	istrcmp();
 
 TypeDicSeg
 srchidx(TypeDicSeg low, int len)

--- a/srchnum.c
+++ b/srchnum.c
@@ -280,7 +280,7 @@ srch_number1(u_char* ptr)
 {
 	u_char		ch;
 	u_char		mode;
-	u_char		TFar	*p;
+	u_char		*p;
 	int		l;
 	TypeClass	cls;
 	int		len;

--- a/stbtbl.c
+++ b/stbtbl.c
@@ -40,7 +40,7 @@
 #include "sj_typedef.h"
 #include "sj_yomi.h"
 #include "sj_hinsi.h"
-static	Uchar	name_stb[] = {  	
+static	u_char	name_stb[] = {
 	0x22, MEISI_1,	_KU, _NN,
 			0xb7, 0xaf,			
 	0x22, MEISI_1,	_SA, _MA,
@@ -56,7 +56,7 @@ static	Uchar	name_stb[] = {
 	0x00
 };
 
-static	Uchar	timei_stb[] = {  	
+static	u_char	timei_stb[] = {
 	0x22, MEISI_1,	_E, _KI,
 		 	0xb1, 0xd8,			
 	0x44, MEISI_1,	_E, _KI, _HA, _TU,
@@ -78,7 +78,7 @@ static	Uchar	timei_stb[] = {
 	0x00
 };
 
-static	Uchar	meisi_stb[] = {		
+static	u_char	meisi_stb[] = {
 	0x44, MEISI_6,	_A, _TU, _KA, _I,
 			0xb0, 0xb7, 0xa4, 0xa4,		
 	0x1a, MEISI_6,	_KA,
@@ -94,7 +94,7 @@ static	Uchar	meisi_stb[] = {
 	0x00
 };
 
-static	Uchar	sahen_stb[] = {		
+static	u_char	sahen_stb[] = {
 	0x44, MEISI_6,	_A, _TU, _KA, _I,
 			0xb0, 0xb7, 0xa4, 0xa4,		
 	0x1a, MEISI_6,	_KA,
@@ -120,13 +120,13 @@ static	Uchar	sahen_stb[] = {
 	0x00
 };
 
-static	Uchar	human_stb[] = {  	
+static	u_char	human_stb[] = {
 	0x24, MEISI_1,	_SA, _NN,
 			0xa4, 0xb5, 0xa4, 0xf3,		
 	0x00
 };
 
-static	Uchar	ippan_stb[] = {		
+static	u_char	ippan_stb[] = {
 	0x56, FUKUSI_1, _NI, _TO, _MO, _NA, _I,	
 			0xa4, 0xcb, 0xc8, 0xbc, 0xa4, 0xa4,	
 	0x56, FUKUSI_1, _NI, _TO, _MO, _NA, _U,	
@@ -134,7 +134,7 @@ static	Uchar	ippan_stb[] = {
 	0x00
 };
 
-Uchar	*stbadr[] = {
+u_char	*stbadr[] = {
 	0,
 	ippan_stb, ippan_stb, ippan_stb, meisi_stb, sahen_stb,
 	sahen_stb, sahen_stb, meisi_stb, meisi_stb, meisi_stb,

--- a/stttbl.c
+++ b/stttbl.c
@@ -41,31 +41,31 @@
 
 
 
-static	Uchar	o_settou[] = {					
+static	u_char	o_settou[] = {
 	0xA1,	0xb8, 0xe6,	0xa4, 0xaa
 };
 
-static	Uchar	go_settou[] = {					
+static	u_char	go_settou[] = {
 	0xA1,	0xb8, 0xe6,	0xa4, 0xb4
 };
 
-static	Uchar	dai_settou[] = {				
+static	u_char	dai_settou[] = {
 	0x22,	0xc2, 0xe8,	0xc2, 0xe8
 };
 
-static	Uchar	kigou_settou[] = {		
+static	u_char	kigou_settou[] = {
 	0x01
 };
 
 
 
-Uchar	*settou_ptr[] = {
+u_char	*settou_ptr[] = {
 	NULL, o_settou, go_settou, dai_settou, kigou_settou
 };
 
 
 
-Uchar	scncttbl[2][24] = {
+u_char	scncttbl[2][24] = {
 	{	
  	     
 		 0x48,  0x80,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,

--- a/study.c
+++ b/study.c
@@ -40,16 +40,16 @@
 #include "sj_kcnv.h"
 #include "kanakan.h"
 
-Void	mvmemi(), mvmemd();
+void	mvmemi(), mvmemd();
 
-Int
+int
 study(STDYOUT *stdy)
 {
 	STDYOUT		outp;
 	STDYIN		*p1;
 	STDYIN		*p2;
-	Int		wcnt;
-	Int		ret;
+	int		wcnt;
+	int		ret;
 	TypeDicSeg	seg;
 	TypeDicOfs	ofs;
 	TypeStyNum	nm;
@@ -57,7 +57,7 @@ study(STDYOUT *stdy)
 
 	if (!StudyExist()) return StudyNoDict;
 
-	memcpy((Uchar *)stdy, (Uchar *)&outp, sizeof(outp));
+	memcpy((u_char *)stdy, (u_char *)&outp, sizeof(outp));
 
 	if (outp.stdy1.offset == 0) return StudyNotStudy;
 
@@ -95,7 +95,7 @@ study(STDYOUT *stdy)
 		}
 
 		if (p2) {
-			mvmemi((Uchar *)(p2 + 1), (Uchar *)p2,
+			mvmemi((u_char *)(p2 + 1), (u_char *)p2,
 				(StudyTail - p2) * StudyRecSize);
 			StudyCount -= 1;
 		}
@@ -123,8 +123,8 @@ study(STDYOUT *stdy)
 		p1++;
 	}
 
-	mvmemd((Uchar *)(StudyTail - 1), (Uchar *)StudyTail,
-			(Uchar *)(StudyTail - 1) - (Uchar *)p1);
+	mvmemd((u_char *)(StudyTail - 1), (u_char *)StudyTail,
+			(u_char *)(StudyTail - 1) - (u_char *)p1);
 	p1 -> offset = outp.stdy1.offset;
 	p1 -> seg    = outp.stdy1.seg;
 	p1 -> dicid  = outp.stdy1.dicid;
@@ -144,9 +144,9 @@ STDYIN* srchstdy(
 	TypeDicOfs ofs,
 	TypeDicID  dicid)
 {
-	Int	high;
-	Int	mid;
-	Int	low;
+	int	high;
+	int	mid;
+	int	low;
 	STDYIN	*ptr;
 
 

--- a/suujitbl.c
+++ b/suujitbl.c
@@ -40,7 +40,7 @@
 
 
 
-Uchar	suuji_tbl[] = {
+u_char	suuji_tbl[] = {
 	N_0,_NIL,_NIL,	_Num0  | NA,		0x00, 0x00,
 	N_1,_NIL,_NIL,	_Num1  | NA,		0xec, 0x07,
 	N_2,_NIL,_NIL,	_Num2  | NA,		0xec, 0x07,
@@ -80,7 +80,7 @@ Uchar	suuji_tbl[] = {
 
 
 
-Uchar	kurai1_tbl[] = {
+u_char	kurai1_tbl[] = {
 	_ZI,_XYU,_U,  	(1<<4)+0+Kr1TblTopF,	0x05,
 	_ZI,_XYU,_XTU,	(1<<4)+1+Kr1TblTopF,	0x02,
 	_SE,_NN, _NIL,	(3<<4)+2+Kr1TblTopF,	0x07,
@@ -96,7 +96,7 @@ Uchar	kurai1_tbl[] = {
 
 
 
-Uchar	kurai2_tbl[] = {
+u_char	kurai2_tbl[] = {
 	_O, _KU, _NIL,	 (2<<4)+13,
 	_TI,_XYO,_U,  	 (3<<4)+14,
 	_MA,_NN, _NIL,	 (1<<4)+15,
@@ -105,7 +105,7 @@ Uchar	kurai2_tbl[] = {
 
 
 
-Uchar	num1tbl[]  = {
+u_char	num1tbl[]  = {
 	0xa3, 0xb0,	
 	0xa3, 0xb1,	
 	0xa3, 0xb2,	
@@ -123,7 +123,7 @@ Uchar	num1tbl[]  = {
 
 
 
-Uchar	num2tbl[]  = {
+u_char	num2tbl[]  = {
 	0xa1, 0xbb,	
 	0xb0, 0xec,	
 	0xc6, 0xf3,	
@@ -141,7 +141,7 @@ Uchar	num2tbl[]  = {
 
 
 
-Uchar	num3tbl[]  = {
+u_char	num3tbl[]  = {
 	0xce, 0xed,	
 	0xb0, 0xed,	
 	0xc6, 0xf5,	
@@ -159,7 +159,7 @@ Uchar	num3tbl[]  = {
 
 
 
-Uchar	num4tbl[] = {
+u_char	num4tbl[] = {
 	0xc0, 0xe9,	
 	0xc9, 0xb4,	
 	0xbd, 0xbd,	
@@ -168,7 +168,7 @@ Uchar	num4tbl[] = {
 
 
 
-Uchar	num5tbl[] = {
+u_char	num5tbl[] = {
 	0xc0, 0xe9,	
 	0xc9, 0xb4,	
 	0xbd, 0xa6,	
@@ -177,7 +177,7 @@ Uchar	num5tbl[] = {
 
 
 
-Uchar	num6tbl[] = {
+u_char	num6tbl[] = {
 	0xc3, 0xfb,	
 	0xb2, 0xaf,	
 	0xcb, 0xfc,	

--- a/terminat.c
+++ b/terminat.c
@@ -38,11 +38,11 @@
 #include "sj_kcnv.h"
 #include "sj_right.h"
 
-Int	terminate(right, yomi)
+int	terminate(right, yomi)
 TypeCnct	right;
-Uchar		*yomi;
+u_char		*yomi;
 {
-	Uchar	ch;
+	u_char	ch;
 
 
 	if ((yomi > cnvstart) && (Chrtbl[*(yomi - 1)] & NUMBER))

--- a/termtbl.c
+++ b/termtbl.c
@@ -33,7 +33,7 @@
 #include "sj_prty.h"
 
 
-Uchar	termtbl[] = {
+u_char	termtbl[] = {
 	0,
 	T_KANOU + P_JOSHI_B,
 	T_KANOU + P_JOSHI_A,

--- a/wakachi.c
+++ b/wakachi.c
@@ -41,8 +41,8 @@
 #include "sj_hinsi.h"
 #include "kanakan.h"
 
-Int	terminate();
-Void	setclrec(), srchfzk();
+int	terminate();
+void	setclrec(), srchfzk();
 
 void
 wakachi (void)
@@ -51,11 +51,11 @@ wakachi (void)
 	CLREC		*clrec;
 
 	CREC		crec[4];
-	Int		count;
-	Uchar		*next;
+	int		count;
+	u_char		*next;
 	TypeCnct	right;
-	Int		i;
-	Int		maxlen;
+	int		i;
+	int		maxlen;
 
 	free_jall(maxjptr);
 	maxjptr = NULL;
@@ -88,7 +88,7 @@ wakachi (void)
 		jrec -> class  = C_WAKACHI;
 		jrec -> hinsi  = MEISI_6;
 
-		while ((Int)jrec -> jlen < maxlen) {
+		while ((int)jrec -> jlen < maxlen) {
 
 			count = setconj((TypeGram)MEISI_6, jrec, crec);
 
@@ -124,7 +124,7 @@ wakachi (void)
 		return;
 
 	if (jrec -> jlen) {
-		if ((clrec = argclrec((Int)jrec -> jlen)) != NULL) {
+		if ((clrec = argclrec((int)jrec -> jlen)) != NULL) {
 			clrec -> jnode   = jrec;
 			clrec -> right   = R_MEISI;
 			clrec -> kubun   = K_TAIGEN;


### PR DESCRIPTION
生成された.oファイルをobjdump -dで比較した範囲では、相違ありません（デバッグ関係の情報は変わっているようで、diffでは違うファイルとして検出されます）。
この次に、sj_define.hを廃止予定です（Static→staticの定義、もう不要でしょう）。