### PR TITLE
Fix

### DIFF
--- a/Funcs.h
+++ b/Funcs.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2023 FUJIMI-IM project
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef SJ3_FUNCS_H_
+#define SJ3_FUNCS_H_
+
+#include "sj_struct.h"
+
+#ifndef SJ3_RK_H_	// "rk.h" not included
+typedef void RkTablW16;
+#endif
+#ifndef _WCHARH		// "wchar16.h" not included
+typedef unsigned short wchar16_t;
+#endif
+
+/* cmpstr.c */
+int cmpstr(unsigned char *, unsigned char *);
+
+/* codecnv.c */
+int init_code(void);
+void printout_mb(FILE *, unsigned char *);
+void printout(FILE *, unsigned char *);
+void normal_out(char *, ...);
+
+/* comuni.c */
+unsigned char *put_string(unsigned char *);
+unsigned char *put_ndata(unsigned char *, int);
+
+/* dictdisp.c */
+void dictdisp(char *output);
+
+/* dictmake.c */
+void  dictmake(char *input);
+
+/* fuzoku.c */
+void setclrec(JREC *, unsigned char *, TypeCnct);
+void srchfzk(JREC *, unsigned char *, TypeCnct, int);
+
+/* hinsi.c */
+char *hns2str(int);
+int str2hns(char *);
+
+/* init.c */
+void mkidxtbl(DICT *);
+void initwork(void);
+
+/* main.c */
+void server_terminate(void);
+
+/* memory2.c */
+JREC *free_jlst(JREC *);
+CLREC *free_clst(CLREC *, int);
+void free_clall(CLREC *);
+void free_jall(JREC *);
+void freework(void);
+
+/* mk2claus.c */
+void mk2claus(void);
+
+/* mvmemd.c */
+void mvmemd(unsigned char *, unsigned char *, int);
+
+/* mvmemi.c */
+void mvmemi(unsigned char *, unsigned char *, int);
+
+/* rk_conv.c */
+int sj3_rkinit_mb(char *);
+char *getkey(char *, wchar16_t *, int *);
+char *rkgetyomi(char *, wchar16_t *, int *);
+void cltable(void);
+int chk_rstr(wchar16_t *, wchar16_t *, int, int);
+int stradd(wchar16_t **, wchar16_t *, int);
+int kstradd(wchar16_t **, wchar16_t *, int);
+RkTablW16 *mktable(wchar16_t *, int);
+void sj3_rkclear(void);
+void sj3_rkreset(void);
+int sj3_rkconv2(wchar16_t *, unsigned int *, int);
+int sj3_rkinit_sub(char *, int (*)(void));
+int sj3_rkconv_w16(wchar16_t *, wchar16_t *);
+int rkmatch(wchar16_t *, wchar16_t *, int);
+
+/* sj2code.c */
+int sj2cd_chr(unsigned char *, unsigned char *);
+
+/* sj3_rkcv.c */
+int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
+int sj_hantozen(wchar16_t *, wchar16_t *, int);
+unsigned short sj_zen2han(unsigned short);
+int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
+int sj_zentohan(wchar16_t *, wchar16_t *, int);
+
+/* selclrec.c */
+void selclrec(void);
+
+/* sjrc.c */
+int getsjrc(void);
+void setrc(char *, FILE *);
+int much(char *, char *);
+int IsTerminator(unsigned char);
+int isTerminator(unsigned char);
+int IsEscape(unsigned char);
+int IsDelimitor(unsigned char);
+
+/* terminat.c */
+int terminate(TypeCnct, unsigned char *);
+
+/* wc16_str.c */
+int sj3_wslen16(wchar16_t *);
+int sj3_wscmp16(wchar16_t *, wchar16_t *);
+int sj3_wsncmp16(wchar16_t *, wchar16_t *, int);
+wchar16_t *sj3_wscpy16(wchar16_t *, wchar16_t *);
+int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
+int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
+
+#endif /* SJ3_FUNCS_H_ */

--- a/adddic.c
+++ b/adddic.c
@@ -42,6 +42,8 @@
 #include "sj_kcnv.h"
 #include "kanakan.h"
 
+void	mvmemi(), mvmemd(), mkidxtbl();
+int	cmpstr();
 
 static unsigned int checkdict(unsigned char* kanji, TypeGram grm);
 static int cal_nextym(unsigned char* ptr);
@@ -296,7 +298,7 @@ adddic(unsigned char* yomi, unsigned char* kanji, TypeGram  hinsi)
 static int
 checksub(unsigned char* kanji, TypeGram grm)
 {
-	unsigned char	*tagp;
+	unsigned char	*tagp = NULL;
 	unsigned char	*ptr;
 	unsigned char	*endp;
 	int	flg, nlen;

--- a/adddic.c
+++ b/adddic.c
@@ -42,8 +42,17 @@
 #include "sj_kcnv.h"
 #include "kanakan.h"
 
-void	mvmemi(), mvmemd(), mkidxtbl();
-int	cmpstr();
+/* cmpstr.c */
+int cmpstr(unsigned char *, unsigned char *);
+
+/* init.c */
+void mkidxtbl(DICT *);
+
+/* mvmemd.c */
+void mvmemd(unsigned char *, unsigned char *, int);
+
+/* mvmemi.c */
+void mvmemi(unsigned char *, unsigned char *, int);
 
 static unsigned int checkdict(unsigned char* kanji, TypeGram grm);
 static int cal_nextym(unsigned char* ptr);
@@ -52,8 +61,7 @@ static void sprt_seg(TypeDicSeg seg, TypeDicOfs ofs);
 static void apnd_uidx(TypeDicSeg seg, unsigned char* yomi, int len);
 
 
-unsigned int
-adddic(unsigned char* yomi, unsigned char* kanji, TypeGram  hinsi)
+unsigned int adddic(unsigned char* yomi, unsigned char* kanji, TypeGram  hinsi)
 {
 	unsigned int	err;
 	unsigned char	yptr[MaxWdYomiLen+1];
@@ -295,8 +303,7 @@ adddic(unsigned char* yomi, unsigned char* kanji, TypeGram  hinsi)
 }
 
 
-static int
-checksub(unsigned char* kanji, TypeGram grm)
+static int checksub(unsigned char* kanji, TypeGram grm)
 {
 	unsigned char	*tagp = NULL;
 	unsigned char	*ptr;
@@ -338,8 +345,7 @@ checksub(unsigned char* kanji, TypeGram grm)
 }
 
 
-static unsigned int
-checkdict(unsigned char* kanji, TypeGram grm)
+static unsigned int checkdict(unsigned char* kanji, TypeGram grm)
 {
 	DICTL	*dp;
 	int	dounum = 0;
@@ -364,8 +370,7 @@ checkdict(unsigned char* kanji, TypeGram grm)
 }
 
 
-static int
-cal_nextym(unsigned char* ptr)
+static int cal_nextym(unsigned char* ptr)
 {
 	int	count = 0;
 	unsigned char	*src;
@@ -388,8 +393,7 @@ cal_nextym(unsigned char* ptr)
 }
 
 
-static int
-usr_freelen(void)
+static int usr_freelen(void)
 {
 	unsigned char* ptr;
 
@@ -400,8 +404,7 @@ usr_freelen(void)
 }
 
 
-static void
-sprt_seg(TypeDicSeg seg, TypeDicOfs ofs)
+static void sprt_seg(TypeDicSeg seg, TypeDicOfs ofs)
 {
 	TypeDicSeg	s;
 	unsigned char	*pos;
@@ -475,8 +478,7 @@ sprt_seg(TypeDicSeg seg, TypeDicOfs ofs)
 }
 
 
-static void
-apnd_uidx(TypeDicSeg seg, unsigned char* yomi, int len)
+static void apnd_uidx(TypeDicSeg seg, unsigned char* yomi, int len)
 {
 	unsigned char	*p;
 	unsigned char	*q;

--- a/adddic.c
+++ b/adddic.c
@@ -41,18 +41,7 @@
 #include "sj_euc.h"
 #include "sj_kcnv.h"
 #include "kanakan.h"
-
-/* cmpstr.c */
-int cmpstr(unsigned char *, unsigned char *);
-
-/* init.c */
-void mkidxtbl(DICT *);
-
-/* mvmemd.c */
-void mvmemd(unsigned char *, unsigned char *, int);
-
-/* mvmemi.c */
-void mvmemi(unsigned char *, unsigned char *, int);
+#include "Funcs.h"
 
 static unsigned int checkdict(unsigned char* kanji, TypeGram grm);
 static int cal_nextym(unsigned char* ptr);

--- a/char.c
+++ b/char.c
@@ -36,8 +36,7 @@
 #include "const.h"
 
 
-int
-cnvyomi(int code)
+int cnvyomi(int code)
 {
 	unsigned short	hh;
 	unsigned char	high;
@@ -93,8 +92,7 @@ cnvyomi(int code)
 }
 
 
-int
-h2kcode(int code)
+int h2kcode(int code)
 {
 	unsigned short	hh;
 	unsigned char	high;
@@ -115,8 +113,7 @@ h2kcode(int code)
 }
 
 
-int
-codesize(unsigned char code)
+int codesize(unsigned char code)
 {
 	switch (code&KanjiModeMask) {
 	      case ZenHiraAssyuku: 
@@ -134,8 +131,7 @@ codesize(unsigned char code)
 }
 
 
-void
-output_knj(FILE* fp, unsigned char* p, int l)
+void output_knj(FILE* fp, unsigned char* p, int l)
 {
 	while (l > 0) {
 		switch (*p & KanjiModeMask) {
@@ -184,15 +180,13 @@ output_knj(FILE* fp, unsigned char* p, int l)
 }
 
 
-void
-output_str(FILE* fp, char* p)
+void output_str(FILE* fp, char* p)
 {
 	while (*p) { fputc(*p, fp); p++; }
 }
 
 
-void
-output_int(FILE* fp, int* p)
+void output_int(FILE* fp, int* p)
 {
 	while (*p) {
 		if (*p < 0x100) {
@@ -217,8 +211,7 @@ output_int(FILE* fp, int* p)
 }
 
 
-static int
-yomi2zen(int code)
+static int yomi2zen(int code)
 {
 	static	char	num[] = {
 		'0', '1', '2', '3', '4', '5', '6', '7',
@@ -255,8 +248,7 @@ yomi2zen(int code)
 }
 
 
-void
-output_yomi(FILE* fp, unsigned char* p)
+void output_yomi(FILE* fp, unsigned char* p)
 {
 	int	i;
 

--- a/char.c
+++ b/char.c
@@ -98,11 +98,9 @@ h2kcode(int code)
 {
 	unsigned short	hh;
 	unsigned char	high;
-	unsigned char	low;
 
 	hh = ((code >> 16) & 0xffff);
 	high = ((code >> 8) & 0xff);
-	low = (code & 0xff);
 
 	if (!hh) {
 		if (high != 0xa4)		

--- a/codecnv.c
+++ b/codecnv.c
@@ -37,10 +37,12 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <locale.h>
 #include "sjctype.h"
 #include "sjtool.h"
+#include "sj3lib.h"
 
 static	int	euc_mode;
 

--- a/codecnv.c
+++ b/codecnv.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <ctype.h>
 #include <locale.h>
 #include "sjctype.h"
@@ -46,8 +47,7 @@
 
 static	int	euc_mode;
 
-int
-init_code()
+int init_code(void)
 {
 	char *loc;
 
@@ -77,9 +77,7 @@ init_code()
 	return 1;
 }
 
-void
-cnvcode(s)
-unsigned char	*s;
+void cnvcode(unsigned char *s)
 {
 	if (euc_mode) {
 		unsigned short	i;
@@ -114,19 +112,13 @@ unsigned char	*s;
 	}
 }
 
-void
-printout_mb(fp, s)
-FILE    *fp;
-unsigned char   *s;
+void printout_mb(FILE *fp, unsigned char *s)
 {
 	fputs((char *)s, fp);
 	fflush(fp);
 }
 
-void
-printout(fp, s) 
-FILE	*fp;
-unsigned char	*s;
+void printout(FILE *fp, unsigned char *s)
 {
 	unsigned char	buf[BUFSIZ];
 
@@ -138,25 +130,25 @@ unsigned char	*s;
 	fflush(fp);
 }
 
-void
-normal_out(fmt, p1, p2, p3, p4, p5)
-char	*fmt;
-int	p1, p2, p3, p4, p5;
+void normal_out(char *fmt, ...)
 {
 	char	buf[BUFSIZ];
+	va_list	ap;
 
-	sprintf(buf, fmt, p1, p2, p3, p4, p5);
+	va_start(ap, fmt);
+	vsprintf(buf, fmt, ap);
+	va_end(ap);
 	printout(stdout, buf);
 }
 
-void
-error_out(fmt, p1, p2, p3, p4, p5)
-char	*fmt;
-int	p1, p2, p3, p4, p5;
+void error_out(char *fmt, ...)
 {
 	char	buf[BUFSIZ];
+	va_list	ap;
 
-	sprintf(buf, fmt, p1, p2, p3, p4, p5);
+	va_start(ap, fmt);
+	vsprintf(buf, fmt, ap);
+	va_end(ap);
 	strcat(buf, "\n");
 	printout(stderr, buf);
 }

--- a/comuni.c
+++ b/comuni.c
@@ -113,8 +113,7 @@ static	int	buflen = 0;
 static	int	getpos = 0;		
 
 
-void
-socket_init(void)
+void socket_init(void)
 {
 #ifdef SVR4
 	int i;
@@ -133,8 +132,7 @@ socket_init(void)
 
 
 
-static void
-set_fd(int fd)
+static void set_fd(int fd)
 {
 #ifdef SVR4
         poll_fds[maxfds].fd = fd;
@@ -148,8 +146,7 @@ set_fd(int fd)
 
 
 
-static void
-clr_fd(int fd)
+static void clr_fd(int fd)
 {
 #ifdef SVR4
 	int i, j;
@@ -182,8 +179,7 @@ clr_fd(int fd)
 #if (!defined(TLI) || (defined(TLI) && defined(SOCK_UNIX)))
 
 
-static void
-open_af_unix(void)
+static void open_af_unix(void)
 {
 	struct sockaddr_un	sunix;
 
@@ -228,8 +224,7 @@ struct netconfig *nconf;
 #endif
 
 
-static void
-open_af_inet(void)
+static void open_af_inet(void)
 {
 #ifdef TLI
         struct t_bind *req;
@@ -386,8 +381,7 @@ open_af_inet(void)
 	set_fd(fd_inet);
 }
 
-void
-open_socket(void)
+void open_socket(void)
 {
 	open_af_inet();
 #if (!defined(TLI) || (defined(TLI) && defined(SOCK_UNIX)))
@@ -398,8 +392,7 @@ open_socket(void)
 #if (!defined(TLI) || (defined(TLI) && defined(SOCK_UNIX)))
 
 
-static int
-connect_af_unix(void)
+static int connect_af_unix(void)
 {
 	struct sockaddr_un	sunix;
 	int	i = sizeof(sunix);
@@ -412,8 +405,7 @@ connect_af_unix(void)
 #endif
 
 #ifdef TLI
-int
-accept_func(int fd, struct t_call* callptr, char* name, int closeflg)
+int accept_func(int fd, struct t_call* callptr, char* name, int closeflg)
 {
         int newfd;  
         int look;
@@ -447,8 +439,7 @@ accept_func(int fd, struct t_call* callptr, char* name, int closeflg)
 
 
 
-static int
-connect_af_inet(void)
+static int connect_af_inet(void)
 {
 #ifndef TLI
 	struct sockaddr_in	sin;
@@ -473,8 +464,7 @@ connect_af_inet(void)
 #if (!defined(TLI) || (defined(TLI) && defined(SOCK_UNIX)))
 
 
-static void
-close_af_unix(void)
+static void close_af_unix(void)
 {
 	struct sockaddr_un	sunix;
 	int	true = 1;
@@ -494,8 +484,7 @@ close_af_unix(void)
 
 
 
-static void
-close_af_inet(void)
+static void close_af_inet(void)
 {
 #ifndef TLI
 	struct sockaddr_in	sin;
@@ -524,8 +513,7 @@ close_af_inet(void)
 #endif
 }
 
-void
-close_socket(void)
+void close_socket(void)
 {
 #if (!defined(TLI) || (defined(TLI) && defined(SOCK_UNIX)))
 	close_af_unix();
@@ -535,11 +523,10 @@ close_socket(void)
 
 
 
-static void
 #ifdef SVR4
-connect_client(struct pollfd *readfds)
+static void connect_client(struct pollfd *readfds)
 #else
-connect_client(fd_set *readfds)
+static void connect_client(fd_set *readfds)
 #endif
 {
 	int	fd;
@@ -640,8 +627,7 @@ connect_client(fd_set *readfds)
 
 
 
-static Client*
-disconnect_client(Client *cp)
+static Client* disconnect_client(Client *cp)
 {
 	WorkArea *wp;
 	StdyFile *sp;
@@ -702,8 +688,7 @@ disconnect_client(Client *cp)
 #include <signal.h>
 #endif
 
-void
-communicate(void)
+void communicate(void)
 {
 	
 	signal(SIGPIPE, SIG_IGN);
@@ -762,8 +747,7 @@ communicate(void)
 }
 
 
-void
-put_flush(void)
+void put_flush(void)
 {
 	int	len;
 	int	i;
@@ -780,24 +764,21 @@ put_flush(void)
 }
 
 
-void
-put_byte(int c)
+void put_byte(int c)
 {
 	putbuf[putpos++] = c;
 	if (putpos >= sizeof(putbuf)) put_flush();
 }
 
 
-void
-put_work(int c)
+void put_work(int c)
 {
 	put_byte(c >> 8);
 	put_byte(c & 0xff);
 }
 
 
-void
-put_int(int c)
+void put_int(int c)
 {
 	put_byte(c >> (8 * 3));
 	put_byte(c >> (8 * 2));
@@ -806,8 +787,7 @@ put_int(int c)
 }
 
 
-unsigned char*
-put_string(unsigned char* p)
+unsigned char* put_string(unsigned char* p)
 {
 	if (p) {
 		do {
@@ -820,16 +800,14 @@ put_string(unsigned char* p)
 }
 
 
-unsigned char*
-put_ndata(unsigned char* p, int n)
+unsigned char* put_ndata(unsigned char* p, int n)
 {
 	while (n-- > 0) put_byte(p ? *p++ : 0);
 	return p;
 }
 
 
-void
-get_buf(void)
+void get_buf(void)
 {
 	int	i;
 
@@ -846,16 +824,14 @@ get_buf(void)
 }
 
 
-int
-get_byte(void)
+int get_byte(void)
 {
 	if (getpos >= buflen) get_buf();
 	return (getbuf[getpos++] & 0xff);
 }
 
 
-int
-get_word(void)
+int get_word(void)
 {
 	int	i;
 
@@ -864,8 +840,7 @@ get_word(void)
 }
 
 
-int
-get_int(void)
+int get_int(void)
 {
 	int	i0;
 	int	i1;
@@ -878,8 +853,7 @@ get_int(void)
 }
 
 
-int
-get_nstring(unsigned char* p, int n)
+int get_nstring(unsigned char* p, int n)
 {
 	int	c;
 
@@ -892,8 +866,7 @@ get_nstring(unsigned char* p, int n)
 }
 
 
-void*
-get_ndata(void * p, int n)
+void* get_ndata(void * p, int n)
 {
 	unsigned char *pp = (unsigned char *)p;
 	while (n-- > 0) *pp++ = get_byte();

--- a/comuni.c
+++ b/comuni.c
@@ -50,6 +50,7 @@
 #include <setjmp.h>
 #include <errno.h>
 #include "server.h"
+#include "kanakan.h"
 #ifdef SVR4
 #include <sys/filio.h>
 #include <sys/signal.h>

--- a/comuni.c
+++ b/comuni.c
@@ -49,6 +49,7 @@
 #include <netdb.h>
 #include <setjmp.h>
 #include <errno.h>
+#include "server.h"
 #ifdef SVR4
 #include <sys/filio.h>
 #include <sys/signal.h>

--- a/comuni.c
+++ b/comuni.c
@@ -892,9 +892,10 @@ get_nstring(unsigned char* p, int n)
 }
 
 
-unsigned char*
-get_ndata(unsigned char* p, int n)
+void*
+get_ndata(void * p, int n)
 {
-	while (n-- > 0) *p++ = get_byte();
-	return p;
+	unsigned char *pp = (unsigned char *)p;
+	while (n-- > 0) *pp++ = get_byte();
+	return pp;
 }

--- a/depend.c
+++ b/depend.c
@@ -47,6 +47,7 @@
 #include "Dict.h"
 #include "sj3err.h"
 #include "kanakan.h"
+#include "Funcs.h"
 
 
 #if defined(__FD_SET) && !defined(FD_SET)
@@ -56,9 +57,6 @@
 
 extern	int	serv_errno;
 extern	Global	*work_base;
-
-/* init.c */
-void	mkidxtbl(DICT *);
 
 DictFile *dictlink = NULL;
 StdyFile *stdylink = NULL;

--- a/depend.c
+++ b/depend.c
@@ -57,6 +57,7 @@
 extern	int	serv_errno;
 extern	Global	*work_base;
 
+void	mkidxtbl();
 
 DictFile *dictlink = NULL;
 StdyFile *stdylink = NULL;

--- a/depend.c
+++ b/depend.c
@@ -111,7 +111,7 @@ fputfile(FILE* fp, long pos, int len, unsigned char* p)
 	return SJ3_NormalEnd;
 }
 
-static int
+static int  __attribute__((unused))
 getfile(int fd, off_t pos, int len, void* p)
 {
 	if (lseek(fd, pos, L_SET) == ERROR) {
@@ -440,7 +440,7 @@ openstdy(char* name, char* passwd)
 	STDYIN		*sp;
 	unsigned short	*cip;
 	unsigned char	*clp;
-	long		stdycnt, stdypos, stdylen, stdymax;
+	long		stdycnt, stdypos, stdylen __attribute__((unused)), stdymax;
 	long		clidxpos, clidxlen;
 	long		clstdypos, clstdylen, clstdystep;
 	long		len;

--- a/dictdisp.c
+++ b/dictdisp.c
@@ -37,7 +37,13 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
+#include "server.h"
+#include "sj3lib.h"
+
+void	printout_mb(), printout();
+char	*hns2str();
 
 void
 dictdisp(output)

--- a/dictdisp.c
+++ b/dictdisp.c
@@ -41,13 +41,7 @@
 #include <ctype.h>
 #include "server.h"
 #include "sj3lib.h"
-
-/* codecnv.c */
-void printout_mb(FILE *, unsigned char *);
-void printout(FILE *, unsigned char *);
-
-/* hinsi.c */
-char *hns2str(int);
+#include "Funcs.h"
 
 void dictdisp(char *output)
 {

--- a/dictdisp.c
+++ b/dictdisp.c
@@ -42,12 +42,14 @@
 #include "server.h"
 #include "sj3lib.h"
 
-void	printout_mb(), printout();
-char	*hns2str();
+/* codecnv.c */
+void printout_mb(FILE *, unsigned char *);
+void printout(FILE *, unsigned char *);
 
-void
-dictdisp(output)
-char	*output;
+/* hinsi.c */
+char *hns2str(int);
+
+void dictdisp(char *output)
 {
 	unsigned char	buf[BUFSIZ];
 	unsigned char	*p;

--- a/dictmake.c
+++ b/dictmake.c
@@ -53,12 +53,14 @@ extern	int	force_flag;
 extern	int	verbose_flag;
 extern  int     _sys_code;
 
-void	normal_out();
-int	str2hns();
-char	*hns2str();
+/* codecnv.c */
+void normal_out(char *, ...);
 
-static void touroku(y, k, h)
-char	*y, *k, *h;
+/* hinsi.c */
+char *hns2str(int);
+int str2hns(char *);
+
+static void touroku(char *y, char *k, char *h)
 {
 	int	err;
 	int	grm;
@@ -131,14 +133,12 @@ char	*y, *k, *h;
 	case SJ3_TOUROKU_FAILED:
 	default:
 		error_out("\305\320\317\277\244\307\244\255\244\336\244\273\244\363\244\307\244\267\244\277 %s:%s:%s(%d)",
-				y, k, hns2str(h), h);
+				y, k, h, str2hns(h));
 		break;
 	}
 }
 
-void
-dictmake(input)
-char	*input;
+void dictmake(char *input)
 {
 	unsigned char	buf[BUFSIZ];
 	FILE	*fp;

--- a/dictmake.c
+++ b/dictmake.c
@@ -45,6 +45,7 @@
 #include "sj3lib.h"
 #include "sjtool.h"
 #include "server.h"
+#include "Funcs.h"
 
 #define	IsEOL(c)	((c) == '\0')
 #define	IsBlank(c)	((c) == ' ' || (c) == '\t')
@@ -52,13 +53,6 @@
 extern	int	force_flag;
 extern	int	verbose_flag;
 extern  int     _sys_code;
-
-/* codecnv.c */
-void normal_out(char *, ...);
-
-/* hinsi.c */
-char *hns2str(int);
-int str2hns(char *);
 
 static void touroku(char *y, char *k, char *h)
 {

--- a/dictmake.c
+++ b/dictmake.c
@@ -38,15 +38,13 @@
 
 #include "sj_sysvdef.h"
 #include <stdio.h>
-#ifdef SVR4
+#include <stdlib.h>
 #include <string.h>
-#else
-#include <strings.h>
-#endif
 #include <ctype.h>
 #include "sjctype.h"
 #include "sj3lib.h"
 #include "sjtool.h"
+#include "server.h"
 
 #define	IsEOL(c)	((c) == '\0')
 #define	IsBlank(c)	((c) == ' ' || (c) == '\t')
@@ -54,6 +52,10 @@
 extern	int	force_flag;
 extern	int	verbose_flag;
 extern  int     _sys_code;
+
+void	normal_out();
+int	str2hns();
+char	*hns2str();
 
 static void touroku(y, k, h)
 char	*y, *k, *h;

--- a/error.c
+++ b/error.c
@@ -40,6 +40,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include <time.h>
 #include "sj_typedef.h"
@@ -55,8 +56,7 @@ static	FILE	*logfp = NULL;
 static	FILE	*dbgfp = NULL;
 
 
-int
-open_error(void)
+int open_error(void)
 {
 	extern	char	*error_file;
 	int	flg = 0;
@@ -76,13 +76,15 @@ open_error(void)
 }
 
 
-void
-error_out(char* s, int p1, int p2, int p3, int p4, int p5)
+void error_out(char* s, ...)
 {
 	char	tmp[BUFSIZ];
+	va_list	ap;
 
 	if (errfp) {
-		sprintf(tmp, s, p1, p2, p3, p4, p5);
+		va_start(ap, s);
+		vsprintf(tmp, s, ap);
+		va_end(ap);
 		fprintf(errfp, "%s: %s\r\n", program_name, tmp);
 		fflush(errfp);
 	}
@@ -90,21 +92,22 @@ error_out(char* s, int p1, int p2, int p3, int p4, int p5)
 }
 
 
-void
-warning_out(char* s, int p1, int p2, int p3, int p4, int p5)
+void warning_out(char* s, ...)
 {
 	char	tmp[BUFSIZ];
+	va_list	ap;
 
 	if (errfp) {
-		sprintf(tmp, s, p1, p2, p3, p4);
+		va_start(ap, s);
+		vsprintf(tmp, s, ap);
+		va_end(ap);
 		fprintf(errfp, "%s: warning: %s\r\n", program_name, tmp);
 		fflush(errfp);
 	}
 }
 
 
-int
-open_log(void)
+int open_log(void)
 {
 	extern	char	*log_file;
 	int	flg = 0;
@@ -134,21 +137,22 @@ open_log(void)
 }
 
 
-void
-logging_out(char* s, int p1, int p2, int p3, int p4, int p5)
+void logging_out(char* s, ...)
 {
 	char	tmp[BUFSIZ];
+	va_list	ap;
 
 	if (logfp) {
-		sprintf(tmp, s, p1, p2, p3, p4, p5);
+		va_start(ap, s);
+		vsprintf(tmp, s, ap);
+		va_end(ap);
 		fprintf(logfp, "%s\r\n", tmp);
 		fflush(logfp);
 	}
 }
 
 
-int
-open_debug(void)
+int open_debug(void)
 {
 	extern	char	*debug_file;
 	int	flg = 0;
@@ -168,11 +172,14 @@ open_debug(void)
 }
 
 
-void
-debug_out(int lvl, char* s, int p1, int p2, int p3, int p4, int p5)
+void debug_out(int lvl, char* s, ...)
 {
+	va_list	ap;
+
 	if (lvl <= debug_level && dbgfp) {
-		fprintf(dbgfp, s, p1, p2, p3, p4, p5);
+		va_start(ap, s);
+		vfprintf(dbgfp, s, ap);
+		va_end(ap);
 		fflush(dbgfp);
 	}
 }

--- a/execute.c
+++ b/execute.c
@@ -51,6 +51,7 @@
 #include "server.h"
 #include "kanakan.h"
 #include "sj3lib.h"
+#include "Funcs.h"
 
 
 #define SJIS_PROTO 1
@@ -83,15 +84,6 @@ static	Client	*cur_cli;
 static unsigned char defaultchar[2] = {(unsigned char)0x81, (unsigned char)0x40};
 static int  defuse=0, defuse2=0;
 
-/* comuni.c */
-unsigned char *put_string(unsigned char *);
-unsigned char *put_ndata(unsigned char *, int);
-
-/* init.c */
-void initwork(void);
-
-/* main.c */
-void server_terminate(void);
 
 
 int make_full_path (char *path)

--- a/execute.c
+++ b/execute.c
@@ -83,14 +83,18 @@ static	Client	*cur_cli;
 static unsigned char defaultchar[2] = {(unsigned char)0x81, (unsigned char)0x40};
 static int  defuse=0, defuse2=0;
 
-void	initwork(), server_terminate();
+/* comuni.c */
+unsigned char *put_string(unsigned char *);
+unsigned char *put_ndata(unsigned char *, int);
 
-unsigned char	*put_ndata(), *put_string();
+/* init.c */
+void initwork(void);
+
+/* main.c */
+void server_terminate(void);
 
 
-
-int
-make_full_path (char *path)
+int make_full_path (char *path)
 {
 	char	tmp[PathNameLen];
 	char    *index;
@@ -121,8 +125,7 @@ make_full_path (char *path)
 
 
 
-WorkArea*
-alloc_workarea (void)
+WorkArea* alloc_workarea (void)
 {
 	WorkArea *p;
 
@@ -141,8 +144,7 @@ alloc_workarea (void)
 	return p;
 }
 
-void
-free_workarea (WorkArea *p)
+void free_workarea (WorkArea *p)
 {
 	if (!p) return;
 	if (--(p -> refcnt)) return;
@@ -168,8 +170,7 @@ free_workarea (WorkArea *p)
 
 
 
-void
-exec_connect (void)
+void exec_connect (void)
 {
 	int	version;
 	char	hostname[HostNameLen];
@@ -224,8 +225,7 @@ exec_connect (void)
 
 
 
-void
-exec_disconnect (void)
+void exec_disconnect (void)
 {
 	if (cur_cli -> stdy) {
 		closestdy(cur_cli -> stdy);
@@ -243,8 +243,7 @@ exec_disconnect (void)
 
 
 
-void
-exec_opendict (void)
+void exec_opendict (void)
 {
 	char	filename[PathNameLen];
 	char	password[PassWordLen];
@@ -319,8 +318,7 @@ exec_opendict (void)
 
 
 
-void
-exec_closedict (void)
+void exec_closedict (void)
 {
 	TypeDicID	id;
 	DICTL	*dictl;
@@ -354,8 +352,7 @@ exec_closedict (void)
 
 
 
-void
-close_dictlist(DICTL *dictl)
+void close_dictlist (DICTL *dictl)
 {
 	DICTL	*p;
 
@@ -370,8 +367,7 @@ close_dictlist(DICTL *dictl)
 
 
 
-void
-exec_openstdy (void)
+void exec_openstdy (void)
 {
 	char	filename[PathNameLen];
 	char	password[PassWordLen];
@@ -392,8 +388,7 @@ exec_openstdy (void)
 
 
 
-void
-exec_closestdy (void)
+void exec_closestdy (void)
 {
 	if (!cur_cli -> stdy) longjmp(error_ret, SJ3_StdyFileNotOpened);
 
@@ -405,8 +400,7 @@ exec_closestdy (void)
 
 
 
-void
-exec_stdysize (void)
+void exec_stdysize (void)
 {
 	put_int(SJ3_NormalEnd);
 	put_int(sizeof(STDYOUT));
@@ -414,8 +408,7 @@ exec_stdysize (void)
 
 
 
-static	void
-exec_lock (void)
+static	void exec_lock (void)
 {
 	int	lock;
 	DICTL	*dl;
@@ -439,8 +432,7 @@ exec_lock (void)
 
 
 
-static	void
-exec_unlock (void)
+static	void exec_unlock (void)
 {
 	int	lock;
 	DICTL	*dl;
@@ -464,8 +456,7 @@ exec_unlock (void)
 
 
 
-static	void
-lock_check_for_read (void)
+static	void lock_check_for_read (void)
 {
 	int	lock;
 
@@ -481,8 +472,7 @@ lock_check_for_read (void)
 }
 
 
-void
-exec_ph2knj (int mb_flag)
+void exec_ph2knj (int mb_flag)
 {
 	int	i, j, l, stdy_size, buf_size, srchead = 0, srclen;
 	unsigned char	*p,*q;
@@ -558,8 +548,7 @@ CCONVERR:
 }
 
 
-void
-exec_cl2knj (int mb_flag)
+void exec_cl2knj (int mb_flag)
 {
 	int	len, stdy_size, buf_size;
 	int	i, j, l;
@@ -623,8 +612,7 @@ CCONVERR:
 }
 
 
-void
-exec_nextcl (int mb_flag)
+void exec_nextcl (int mb_flag)
 {
 	int	mode, stdy_size, buf_size;
 	int	i, l;
@@ -676,8 +664,7 @@ CCONVERR:
 }
 
 
-void
-exec_prevcl (int mb_flag)
+void exec_prevcl (int mb_flag)
 {
 	int	mode, stdy_size, buf_size;
 	int	i, l;
@@ -730,8 +717,7 @@ CCONVERR:
 }
 
 
-void
-exec_cl2knj_cnt(int mb_flag)
+void exec_cl2knj_cnt(int mb_flag)
 {
 	int	len, buf_size, stdy_size;
 	int	i;
@@ -778,8 +764,7 @@ CCONVERR:
 }
 
 
-void
-exec_cl2knj_all (int mb_flag)
+void exec_cl2knj_all (int mb_flag)
 {
 	int	len, stdy_size, buf_size;
 	int	i, l;
@@ -878,8 +863,7 @@ CCONVERR:
 
 
 
-void
-exec_study (void)
+void exec_study (void)
 {
 	int	err;
 	STDYOUT	stdy;
@@ -906,8 +890,7 @@ exec_study (void)
 }
 
 
-void
-exec_clstudy (int mb_flag)
+void exec_clstudy (int mb_flag)
 {
 	int	err;
 	STDYOUT	stdy;
@@ -951,8 +934,7 @@ CCONVERR:
 }
 
 
-void
-exec_adddict (int mb_flag)
+void exec_adddict (int mb_flag)
 {
 	TypeDicID	dicid;
 	TypeGram	gram;
@@ -1014,8 +996,7 @@ CCONVERR:
         return;
 }
 
-void
-exec_deldict (int mb_flag)
+void exec_deldict (int mb_flag)
 {
 	TypeDicID	dicid;
 	TypeGram	gram;
@@ -1075,8 +1056,7 @@ CCONVERR:
 }
 
 
-void
-exec_getdict (int mb_flag)
+void exec_getdict (int mb_flag)
 {
 	TypeDicID	dicid;
 	int		err, buf_size, l;
@@ -1159,8 +1139,7 @@ CCONVERR:
 
 
 
-void
-exec_nextdict (int mb_flag)
+void exec_nextdict (int mb_flag)
 {
 	TypeDicID	dicid;
 	int		err, buf_size, l;
@@ -1243,8 +1222,7 @@ CCONVERR:
 
 
 
-void
-exec_prevdict (int mb_flag)
+void exec_prevdict (int mb_flag)
 {
 	TypeDicID	dicid;
 	int		err, buf_size, l;
@@ -1327,8 +1305,7 @@ CCONVERR:
 
 
 
-void
-exec_makedict (void)
+void exec_makedict (void)
 {
 	struct stat    sbuf;
 	char	path[PathNameLen];
@@ -1356,8 +1333,7 @@ exec_makedict (void)
 
 
 
-void
-exec_makestdy (void)
+void exec_makestdy (void)
 {
 	struct stat    sbuf;
 	char	path[PathNameLen];
@@ -1385,8 +1361,7 @@ exec_makestdy (void)
 
 
 
-void
-exec_access (void)
+void exec_access (void)
 {
 	char	path[PathNameLen];
 	int	mode;
@@ -1402,8 +1377,7 @@ exec_access (void)
 
 
 
-void
-exec_makedir (void)
+void exec_makedir (void)
 {
 	char	path[PathNameLen];
 	int	i;
@@ -1425,8 +1399,7 @@ exec_makedir (void)
 
 
 
-void
-exec_who (void)
+void exec_who (void)
 {
 	int	i;
 	Client	*cli;
@@ -1452,8 +1425,7 @@ exec_who (void)
 
 
 
-void
-exec_kill (void)
+void exec_kill (void)
 {
 	put_int(SJ3_NormalEnd);
 	put_flush();
@@ -1463,8 +1435,7 @@ exec_kill (void)
 
 
 
-void
-exec_quit (void)
+void exec_quit (void)
 {
 	if (client_num > 1) longjmp(error_ret, SJ3_UserConnected);
 	exec_kill();
@@ -1472,8 +1443,7 @@ exec_quit (void)
 
 
 
-void
-exec_version (void)
+void exec_version (void)
 {
 	extern	char	*version_number, *time_stamp;
 	static	char	*Version = "version : ";
@@ -1489,8 +1459,7 @@ exec_version (void)
 
 
 
-void
-exec_dictpass (void)
+void exec_dictpass (void)
 {
 	TypeDicID	dicid;
 	char		buf[PasswdLen + 1];
@@ -1515,8 +1484,7 @@ exec_dictpass (void)
 
 
 
-void
-exec_dictcmnt (void)
+void exec_dictcmnt (void)
 {
 	TypeDicID	dicid;
 	char		buf[CommentLength + 1];
@@ -1541,8 +1509,7 @@ exec_dictcmnt (void)
 
 
 
-void
-exec_stdypass (void)
+void exec_stdypass (void)
 {
 	char	buf[PasswdLen + 1];
 	int	err;
@@ -1560,8 +1527,7 @@ exec_stdypass (void)
 
 
 
-void
-exec_stdycmnt (void)
+void exec_stdycmnt (void)
 {
 	char	buf[CommentLength + 1];
 	int	err;
@@ -1579,8 +1545,7 @@ exec_stdycmnt (void)
 
 
 
-void
-exec_stdypara (void)
+void exec_stdypara (void)
 {
 	int	stynum, clstep, cllen;
 
@@ -1596,8 +1561,7 @@ exec_stdypara (void)
 
 
 
-void
-execute_cmd (void)
+void execute_cmd (void)
 {
 	int	i;
 

--- a/execute.c
+++ b/execute.c
@@ -49,6 +49,8 @@
 #include "sj3err.h"
 #include "Dict.h"
 #include "server.h"
+#include "kanakan.h"
+#include "sj3lib.h"
 
 
 #define SJIS_PROTO 1
@@ -81,10 +83,7 @@ static	Client	*cur_cli;
 static unsigned char defaultchar[2] = {(unsigned char)0x81, (unsigned char)0x40};
 static int  defuse=0, defuse2=0;
 
-DictFile *opendict();
-int	closedict();
-StdyFile *openstdy();
-int	closestdy();
+void	initwork(), server_terminate();
 
 unsigned char	*put_ndata(), *put_string();
 

--- a/execute.c
+++ b/execute.c
@@ -1333,7 +1333,6 @@ exec_makedict (void)
 	struct stat    sbuf;
 	char	path[PathNameLen];
 	int	err;
-	int	ofslen;
 	int	idxlen;
 	int	seglen;
 	int	segnum;

--- a/hinsi.c
+++ b/hinsi.c
@@ -36,6 +36,7 @@
 
 
 
+#include <string.h>
 #include "sj_hinsi.h"
 
 static	struct	hlist {

--- a/hinsi.c
+++ b/hinsi.c
@@ -233,8 +233,7 @@ static	struct	hlist {
 	{0,		0}
 };
 
-char	*hns2str(code)
-int	code;
+char	*hns2str(int code)
 {
 	struct	hlist	*p;
 
@@ -246,8 +245,7 @@ int	code;
 	return "ERROR";
 }
 
-int	str2hns(str)
-char	*str;
+int	str2hns(char *str)
 {
 	struct	hlist	*p;
 

--- a/level1.c
+++ b/level1.c
@@ -103,7 +103,7 @@ put_byte(int c)
 	putbuf[putpos++] = c;
 }
 
-static void
+static void __attribute__((unused))
 put_word(int c)
 {
 	put_byte(c >> 8);
@@ -214,7 +214,7 @@ get_byte(void)
 	return (getbuf[getpos++] & 0xff);
 }
 
-static int
+static int __attribute__((unused))
 get_word(void)
 {
 	int	i;
@@ -382,8 +382,6 @@ sj3_make_connection(SJ3_CLIENT_ENV *client,
 	char	 host[MAXHOSTNAMELEN];
 	int	 tmp;
 	int	 hostlen, userlen, proglen, datalen, buflen;
-	int	 curlen;
-	char	*curdata;
 
 	client->fd = -1;
 

--- a/level1.c
+++ b/level1.c
@@ -266,7 +266,7 @@ get_nstring(unsigned char *p, int n)
 	return n;
 }
 
-static unsigned char *
+static void *
 get_ndata(void *p, int n)
 {
 	unsigned char *pp = (unsigned char *)p;

--- a/level1.c
+++ b/level1.c
@@ -77,8 +77,7 @@ static int     ReadErrorFlag = FALSE;
 		}							\
 	}
 
-static int
-put_flush(void)
+static int put_flush(void)
 {
 	int	 i, j;
 	unsigned char	*p;
@@ -97,21 +96,18 @@ put_flush(void)
 	return 0;
 }
 
-static void
-put_byte(int c)
+static void put_byte(int c)
 {
 	putbuf[putpos++] = c;
 }
 
-static void __attribute__((unused))
-put_word(int c)
+static void __attribute__((unused)) put_word(int c)
 {
 	put_byte(c >> 8);
 	put_byte(c & 0xff);
 }
 
-static void
-put_int(int c)
+static void put_int(int c)
 {
 	put_byte(c >> (8 * 3));
 	put_byte(c >> (8 * 2));
@@ -119,8 +115,7 @@ put_int(int c)
 	put_byte(c);
 }
 
-static void
-put_cmd(int cmd)
+static void put_cmd(int cmd)
 {
 	ReadErrorFlag = FALSE;
 	putpos = getlen = 0;
@@ -129,8 +124,7 @@ put_cmd(int cmd)
 
 #define put_string put_ndata
 
-static unsigned char *
-put_ndata(void *p, int n)
+static unsigned char *put_ndata(void *p, int n)
 {
 	unsigned char *pp = (unsigned char *)p;
 
@@ -139,12 +133,7 @@ put_ndata(void *p, int n)
 	return pp;
 }
 
-static int
-put_over(int buflen, int n,
-    unsigned char *(*func1)(), void *str1, int len1,
-    unsigned char *(*func2)(), void *str2, int len2,
-    unsigned char *(*func3)(), void *str3, int len3,
-    unsigned char *(*func4)(), void *str4, int len4)
+static int put_over(int buflen, int n, unsigned char *(*func1)(), void *str1, int len1, unsigned char *(*func2)(), void *str2, int len2, unsigned char *(*func3)(), void *str3, int len3, unsigned char *(*func4)(), void *str4, int len4)
 {
 #define ARGNUM 4
 	unsigned char *(*func[ARGNUM])();
@@ -186,8 +175,7 @@ put_over(int buflen, int n,
 	return 0;
 }
 
-static int
-get_buffer(void)
+static int get_buffer(void)
 {
 	if (ReadErrorFlag)
 		return ERROR;
@@ -204,8 +192,7 @@ get_buffer(void)
 	return getlen;
 }
 
-static unsigned char
-get_byte(void)
+static unsigned char get_byte(void)
 {
 	if ((getpos >= getlen) && (get_buffer() == ERROR)) {
 		ReadErrorFlag = TRUE;
@@ -214,8 +201,7 @@ get_byte(void)
 	return (getbuf[getpos++] & 0xff);
 }
 
-static int __attribute__((unused))
-get_word(void)
+static int __attribute__((unused)) get_word(void)
 {
 	int	i;
 
@@ -223,8 +209,7 @@ get_word(void)
 	return ((i << 8) | get_byte());
 }
 
-static int
-get_int(void)
+static int get_int(void)
 {
 	int    i0;
 	int    i1;
@@ -236,8 +221,7 @@ get_int(void)
 	return ((i0 << (8*3)) | (i1 << (8*2)) | (i2 << (8*1)) | get_byte());
 }
 
-static unsigned char *
-get_string(unsigned char *p)
+static unsigned char *get_string(unsigned char *p)
 {
 	int	c;
 
@@ -248,8 +232,7 @@ get_string(unsigned char *p)
 	return p;
 }
 
-static int
-get_nstring(unsigned char *p, int n)
+static int get_nstring(unsigned char *p, int n)
 {
 	int	c;
 
@@ -266,8 +249,7 @@ get_nstring(unsigned char *p, int n)
 	return n;
 }
 
-static void *
-get_ndata(void *p, int n)
+static void *get_ndata(void *p, int n)
 {
 	unsigned char *pp = (unsigned char *)p;
 	while (n-- > 0)
@@ -275,22 +257,19 @@ get_ndata(void *p, int n)
 	return pp;
 }
 
-static void
-skip_string(void)
+static void skip_string(void)
 {
 	while (get_byte())
 		;
 }
 
-static void
-skip_ndata(int n)
+static void skip_ndata(int n)
 {
 	while (n-- > 0)
 		get_byte();
 }
 
-static int
-open_unix(void)
+static int open_unix(void)
 {
 	int			fd, len;
 	struct sockaddr_un	sunix;
@@ -316,19 +295,16 @@ open_unix(void)
 	return fd;
 }
 
-void
-sj3_set_timeout(int timeout)
+void sj3_set_timeout(int timeout)
 {
 	sj3_timeout = timeout;
 }
 
-static void
-connect_timeout(void)
+static void connect_timeout(void)
 {
 }
 
-static int
-open_inet(char *host)
+static int open_inet(char *host)
 {
 	struct hostent		*hp;
 	struct servent		*sp;
@@ -373,11 +349,7 @@ open_inet(char *host)
 	return fd;
 }
 
-int
-sj3_make_connection(SJ3_CLIENT_ENV *client,
-    char *serv,
-    char *user,
-    char *prog)
+int sj3_make_connection(SJ3_CLIENT_ENV *client, char *serv, char *user, char *prog)
 {
 	char	 host[MAXHOSTNAMELEN];
 	int	 tmp;
@@ -468,8 +440,7 @@ sj3_make_connection(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_erase_connection(SJ3_CLIENT_ENV *client)
+int sj3_erase_connection(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -485,9 +456,7 @@ sj3_erase_connection(SJ3_CLIENT_ENV *client)
 	return sj3_error_number ? ERROR : 0;
 }
 
-long
-sj3_open_dictionary(SJ3_CLIENT_ENV *client,
-    char *dictname, char *password)
+long sj3_open_dictionary(SJ3_CLIENT_ENV *client, char *dictname, char *password)
 {
 	int res;
 	int dictlen, passlen;
@@ -518,8 +487,7 @@ sj3_open_dictionary(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : res;
 }
 
-int
-sj3_close_dictionary(SJ3_CLIENT_ENV *client, long dicid)
+int sj3_close_dictionary(SJ3_CLIENT_ENV *client, long dicid)
 {
 	client_init(client);
 
@@ -533,9 +501,7 @@ sj3_close_dictionary(SJ3_CLIENT_ENV *client, long dicid)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_open_study_file(SJ3_CLIENT_ENV *client,
-    char *stdyname, char *password)
+int sj3_open_study_file(SJ3_CLIENT_ENV *client, char *stdyname, char *password)
 {
 	int stdylen, passlen;
 	int datalen, buflen;
@@ -564,8 +530,7 @@ sj3_open_study_file(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_close_study_file(SJ3_CLIENT_ENV *client)
+int sj3_close_study_file(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -578,8 +543,7 @@ sj3_close_study_file(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_get_id_size(SJ3_CLIENT_ENV *client)
+int sj3_get_id_size(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -593,8 +557,7 @@ sj3_get_id_size(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : cliptr->stdy_size;
 }
 
-int
-sj3_lock_server(SJ3_CLIENT_ENV *client)
+int sj3_lock_server(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -607,8 +570,7 @@ sj3_lock_server(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_unlock_server(SJ3_CLIENT_ENV *client)
+int sj3_unlock_server(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -621,12 +583,7 @@ sj3_unlock_server(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_ikkatu_henkan(SJ3_CLIENT_ENV *client,
-    unsigned char *src,
-    unsigned char *dst,
-    int dstsiz,
-    int mb_flag)
+int sj3_ikkatu_henkan(SJ3_CLIENT_ENV *client, unsigned char *src, unsigned char *dst, int dstsiz, int mb_flag)
 {
 	int	 c;
 	unsigned char	*top;
@@ -698,12 +655,7 @@ error2:
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_bunsetu_henkan(SJ3_CLIENT_ENV *client,
-    unsigned char *yomi,
-    int len,
-    unsigned char *kanji,
-    int mb_flag)
+int sj3_bunsetu_henkan(SJ3_CLIENT_ENV *client, unsigned char *yomi, int len, unsigned char *kanji, int mb_flag)
 {
 	int	result;
 	int	buflen;
@@ -734,11 +686,7 @@ sj3_bunsetu_henkan(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_bunsetu_jikouho(SJ3_CLIENT_ENV *client,
-    unsigned char *kanji,
-    int mode,
-    int mb_flag)
+int sj3_bunsetu_jikouho(SJ3_CLIENT_ENV *client, unsigned char *kanji, int mode, int mb_flag)
 {
 	int	result;
 
@@ -760,9 +708,7 @@ sj3_bunsetu_jikouho(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_bunsetu_maekouho(SJ3_CLIENT_ENV *client,
-    unsigned char *kanji, int mode, int mb_flag)
+int sj3_bunsetu_maekouho(SJ3_CLIENT_ENV *client, unsigned char *kanji, int mode, int mb_flag)
 {
 	int	result;
 
@@ -784,11 +730,7 @@ sj3_bunsetu_maekouho(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_bunsetu_kouhosuu(SJ3_CLIENT_ENV *client,
-    unsigned char *yomi,
-    int len,
-    int mb_flag)
+int sj3_bunsetu_kouhosuu(SJ3_CLIENT_ENV *client, unsigned char *yomi, int len, int mb_flag)
 {
 	int result;
 	int buflen;
@@ -818,12 +760,7 @@ sj3_bunsetu_kouhosuu(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_bunsetu_zenkouho(SJ3_CLIENT_ENV *client,
-    unsigned char *yomi,
-    int len,
-    SJ3_DOUON *douon,
-    int mb_flag)
+int sj3_bunsetu_zenkouho(SJ3_CLIENT_ENV *client, unsigned char *yomi, int len, SJ3_DOUON *douon, int mb_flag)
 {
 	int	cnt = 0;
 	int	buflen;
@@ -860,8 +797,7 @@ sj3_bunsetu_zenkouho(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : cnt;
 }
 
-int
-sj3_tango_gakusyuu(SJ3_CLIENT_ENV *client, SJ3_STUDYREC *stdy)
+int sj3_tango_gakusyuu(SJ3_CLIENT_ENV *client, SJ3_STUDYREC *stdy)
 {
 	int buflen;
 
@@ -883,12 +819,7 @@ sj3_tango_gakusyuu(SJ3_CLIENT_ENV *client, SJ3_STUDYREC *stdy)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_bunsetu_gakusyuu(SJ3_CLIENT_ENV *client,
-    unsigned char *yomi1,
-    unsigned char *yomi2,
-    SJ3_STUDYREC *stdy,
-    int mb_flag)
+int sj3_bunsetu_gakusyuu(SJ3_CLIENT_ENV *client, unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *stdy, int mb_flag)
 {
 	int yomilen1, yomilen2;
 	int datalen, buflen;
@@ -921,13 +852,7 @@ sj3_bunsetu_gakusyuu(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_tango_touroku(SJ3_CLIENT_ENV *client,
-    long dicid,
-    unsigned char *yomi,
-    unsigned char *kanji,
-    int code,
-    int mb_flag)
+int sj3_tango_touroku(SJ3_CLIENT_ENV *client, long dicid, unsigned char *yomi, unsigned char *kanji, int code, int mb_flag)
 {
 	int yomilen, kanjilen;
 	int datalen, buflen;
@@ -961,13 +886,7 @@ sj3_tango_touroku(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_tango_sakujo(SJ3_CLIENT_ENV *client,
-    long dicid,
-    unsigned char *yomi,
-    unsigned char *kanji,
-    int code,
-    int mb_flag)
+int sj3_tango_sakujo(SJ3_CLIENT_ENV *client, long dicid, unsigned char *yomi, unsigned char *kanji, int code, int mb_flag)
 {
 	int yomilen, kanjilen;
 	int datalen, buflen;
@@ -1001,11 +920,7 @@ sj3_tango_sakujo(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_tango_syutoku(SJ3_CLIENT_ENV *client,
-    int dicid,
-    unsigned char *buf,
-    int mb_flag)
+int sj3_tango_syutoku(SJ3_CLIENT_ENV *client, int dicid, unsigned char *buf, int mb_flag)
 {
 	unsigned char	*p;
 
@@ -1028,11 +943,7 @@ sj3_tango_syutoku(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_tango_jikouho(SJ3_CLIENT_ENV *client,
-    int dicid,
-    unsigned char *buf,
-    int mb_flag)
+int sj3_tango_jikouho(SJ3_CLIENT_ENV *client, int dicid, unsigned char *buf, int mb_flag)
 {
 	unsigned char	*p;
 
@@ -1055,11 +966,7 @@ sj3_tango_jikouho(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_tango_maekouho(SJ3_CLIENT_ENV *client,
-    int dicid,
-    unsigned char *buf,
-    int mb_flag)
+int sj3_tango_maekouho(SJ3_CLIENT_ENV *client, int dicid, unsigned char *buf, int mb_flag)
 {
 	unsigned char	*p;
 
@@ -1082,12 +989,7 @@ sj3_tango_maekouho(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_make_dict_file(SJ3_CLIENT_ENV *client,
-    char *path,
-    int idxlen,
-    int seglen,
-    int segnum)
+int sj3_make_dict_file(SJ3_CLIENT_ENV *client, char *path, int idxlen, int seglen, int segnum)
 {
 	int pathlen;
 	int buflen, datalen;
@@ -1117,12 +1019,7 @@ sj3_make_dict_file(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_make_study_file(SJ3_CLIENT_ENV *client,
-    char *path,
-    int stynum,
-    int clstep,
-    int cllen)
+int sj3_make_study_file(SJ3_CLIENT_ENV *client, char *path, int stynum, int clstep, int cllen)
 {
 	int pathlen;
 	int buflen, datalen;
@@ -1152,8 +1049,7 @@ sj3_make_study_file(SJ3_CLIENT_ENV *client,
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_make_directory(SJ3_CLIENT_ENV *client, char *path)
+int sj3_make_directory(SJ3_CLIENT_ENV *client, char *path)
 {
 	int pathlen;
 	int buflen;
@@ -1178,8 +1074,7 @@ sj3_make_directory(SJ3_CLIENT_ENV *client, char *path)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_access(SJ3_CLIENT_ENV *client, char *path, int mode)
+int sj3_access(SJ3_CLIENT_ENV *client, char *path, int mode)
 {
 	int result;
 	int pathlen;
@@ -1207,8 +1102,7 @@ sj3_access(SJ3_CLIENT_ENV *client, char *path, int mode)
 	return ReadErrorFlag ? ERROR : result;
 }
 
-int
-sj3_who(SJ3_CLIENT_ENV *client, SJ3_WHO_STRUCT *ret, int num)
+int sj3_who(SJ3_CLIENT_ENV *client, SJ3_WHO_STRUCT *ret, int num)
 {
 	int	i, j;
 
@@ -1242,8 +1136,7 @@ sj3_who(SJ3_CLIENT_ENV *client, SJ3_WHO_STRUCT *ret, int num)
 	return ReadErrorFlag ? ERROR : ((i < num) ? i : num);
 }
 
-int
-sj3_quit(SJ3_CLIENT_ENV *client)
+int sj3_quit(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -1256,8 +1149,7 @@ sj3_quit(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_kill(SJ3_CLIENT_ENV *client)
+int sj3_kill(SJ3_CLIENT_ENV *client)
 {
 	client_init(client);
 
@@ -1270,8 +1162,7 @@ sj3_kill(SJ3_CLIENT_ENV *client)
 	return ReadErrorFlag ? ERROR : 0;
 }
 
-int
-sj3_version(SJ3_CLIENT_ENV *client, char *dst, int dstsiz)
+int sj3_version(SJ3_CLIENT_ENV *client, char *dst, int dstsiz)
 {
 	int	c;
 

--- a/main.c
+++ b/main.c
@@ -53,10 +53,7 @@ extern char	*lock_file;
 char	*version_number = "2.08C";
 char	*time_stamp = "Mon Mar 23 16:42:59 JST 1998";
 
-
-
-static void
-opening(void)
+static void opening(void)
 {
 	printf("Kana-Kanji Conversion Server Version %s\r\n", version_number);
 	printf("Copyright (c) 1990-1995 Sony Corporation\r\n");
@@ -65,8 +62,7 @@ opening(void)
 
 #ifdef	LOCK_FILE
 
-int
-make_lockfile(void)
+int make_lockfile(void)
 {
 	int	fd;
 
@@ -77,21 +73,18 @@ make_lockfile(void)
 	return 0;
 }
 
-int
-erase_lockfile(void)
+int erase_lockfile(void)
 {
 	return unlink(lock_file);
 }
 #endif
 
-static void
-signal_handler(int sig)
+static void signal_handler(int sig)
 {
 	warning_out("signal %d catched.", sig);
 }
 
-static void
-terminate_handler(int sig)
+static void terminate_handler(int sig)
 {
 	close_socket();
 	sj_closeall();
@@ -101,8 +94,7 @@ terminate_handler(int sig)
 	exit(0);
 }
 
-void
-server_terminate(void)
+void server_terminate(void)
 {
 	close_socket();
 	sj_closeall();
@@ -112,8 +104,7 @@ server_terminate(void)
 	exit(0);
 }
 
-static void
-exec_fork(void)
+static void exec_fork(void)
 {
 	int	tmp;
 
@@ -142,8 +133,7 @@ exec_fork(void)
 		signal(SIGTSTP, SIG_IGN);
 }
 
-static void
-leave_tty(void)
+static void leave_tty(void)
 {
 	int	tmp;
 
@@ -164,8 +154,7 @@ leave_tty(void)
 	}
 }
 
-int
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	opening();
 #ifndef __NetBSD__

--- a/main.c
+++ b/main.c
@@ -45,12 +45,15 @@
 
 #include "const.h"
 #include "server.h"
+#include "kanakan.h"
 
 extern int	 fork_flag;
 extern char	*lock_file;
 
 char	*version_number = "2.08C";
 char	*time_stamp = "Mon Mar 23 16:42:59 JST 1998";
+
+
 
 static void
 opening(void)
@@ -81,13 +84,13 @@ erase_lockfile(void)
 }
 #endif
 
-static int
+static void
 signal_handler(int sig)
 {
 	warning_out("signal %d catched.", sig);
 }
 
-static int
+static void
 terminate_handler(int sig)
 {
 	close_socket();

--- a/memory2.c
+++ b/memory2.c
@@ -77,7 +77,6 @@ int	l;
 	CLREC	*cpk;
 	CLREC	*cp;
 	CLREC	*cn;
-	int	i = FALSE;
 
 	cp = cpk = NULL;
 

--- a/memory2.c
+++ b/memory2.c
@@ -36,11 +36,9 @@
 
 
 #include "sj_kcnv.h"
+#include "kanakan.h"
 
-void	free_jrec(), free_clrec();
-
-JREC	*free_jlst(p)
-JREC	*p;
+JREC	*free_jlst(JREC *p)
 {
 	JREC	*jpk;
 	JREC	*jp;
@@ -70,9 +68,7 @@ JREC	*p;
 	return jpk;
 }
 
-CLREC	*free_clst(p, l)
-CLREC	*p;
-int	l;
+CLREC	*free_clst(CLREC *p, int l)
 {
 	CLREC	*cpk;
 	CLREC	*cp;
@@ -114,8 +110,7 @@ int	l;
 	return cpk;
 }
 
-void	free_clall(p)
-CLREC	*p;
+void	free_clall(CLREC *p)
 {
 	CLREC	*next;
 
@@ -127,8 +122,7 @@ CLREC	*p;
 	}
 }
 
-void	free_jall(p)
-JREC	*p;
+void	free_jall(JREC *p)
 {
 	JREC	*next;
 
@@ -139,7 +133,7 @@ JREC	*p;
 	}
 }
 
-void	freework()
+void	freework(void)
 {
 	free_clall(maxclptr);
 	clt1st = maxclptr = NULL;

--- a/ph2knj.c
+++ b/ph2knj.c
@@ -41,20 +41,23 @@
 #include "sj_yomi.h"
 #include "kanakan.h"
 
+/* memory2.c */
+JREC *free_jlst(JREC *);
+CLREC *free_clst(CLREC *, int);
+void free_clall(CLREC *);
+void free_jall(JREC *);
+void freework(void);
 
-int	sj2cd_chr();
-void	mk2claus();
-void	freework();
-void    selclrec();
-CLREC	*free_clst();
-JREC	*free_jlst();
-void	free_clall();
-void	free_jall();
+/* mk2claus.c */
+void mk2claus(void);
 
+/* selclrec.c */
+void selclrec(void);
 
+/* sj2code.c */
+int sj2cd_chr(unsigned char *, unsigned char *);
 
-int	ph2knj
-(unsigned char *zyomi, unsigned char *kanji, int knjlen)
+int ph2knj(unsigned char *zyomi, unsigned char *kanji, int knjlen)
 {
 	unsigned char	*ptr;
 	unsigned char	*dst;

--- a/ph2knj.c
+++ b/ph2knj.c
@@ -40,22 +40,7 @@
 #include "sj_kcnv.h"
 #include "sj_yomi.h"
 #include "kanakan.h"
-
-/* memory2.c */
-JREC *free_jlst(JREC *);
-CLREC *free_clst(CLREC *, int);
-void free_clall(CLREC *);
-void free_jall(JREC *);
-void freework(void);
-
-/* mk2claus.c */
-void mk2claus(void);
-
-/* selclrec.c */
-void selclrec(void);
-
-/* sj2code.c */
-int sj2cd_chr(unsigned char *, unsigned char *);
+#include "Funcs.h"
 
 int ph2knj(unsigned char *zyomi, unsigned char *kanji, int knjlen)
 {

--- a/ph2knj.c
+++ b/ph2knj.c
@@ -48,6 +48,8 @@ void	freework();
 void    selclrec();
 CLREC	*free_clst();
 JREC	*free_jlst();
+void	free_clall();
+void	free_jall();
 
 
 

--- a/readline.c
+++ b/readline.c
@@ -110,7 +110,6 @@ readhinsi(void)
 	static int	c = 0;
 	int	i;
 	unsigned char	hinsi[128];
-	int	flg;
 
 retry:
 	

--- a/readline.c
+++ b/readline.c
@@ -52,8 +52,7 @@ static	int	atr[MaxAtrNumber + 1];
 
 
 
-static void
-error(char *s)
+static void error(char *s)
 {
 	if (s) fprintf(stderr, "%s\n", s);
 	mark_file(stderr);
@@ -63,8 +62,7 @@ error(char *s)
 
 
 
-static int
-readchar(void)
+static int readchar(void)
 {
 	int	c1;
 	int	c2;
@@ -90,8 +88,7 @@ readchar(void)
 
 
 
-static int
-skip_blank(void)
+static int skip_blank(void)
 {
 	int	c;
 
@@ -104,8 +101,7 @@ skip_blank(void)
 
 
 
-static int
-readhinsi(void)
+static int readhinsi(void)
 {
 	static int	c = 0;
 	int	i;
@@ -184,8 +180,7 @@ retry:
 
 
 
-int*
-readline(void)
+int* readline(void)
 {
 	int	c;
 	int	i;
@@ -265,8 +260,7 @@ readline(void)
 }
 
 
-void
-setline(void (*func)(int*, int*, int, int*))
+void setline(void (*func)(int*, int*, int, int*))
 {
 	int	i;
 

--- a/rk.h
+++ b/rk.h
@@ -63,8 +63,8 @@
 #define	RKMASK		0x0000ffff
 #define	RKZEN		0xff00
 
-#define SetMojilen(c)	((c << 16) & 0x00ff0000)
-#define GetMojilen(c)	((c & ERRCODE) ? (1) : ((c >> 16) & 0xff)) 
+#define SetMojilen(c)	(((c) << 16) & 0x00ff0000)
+#define GetMojilen(c)	(((c) & ERRCODE) ? (1) : (((c) >> 16) & 0xff)) 
 
 typedef	struct rktable_w16 {
 	wchar16_t *r_key;

--- a/rk.h
+++ b/rk.h
@@ -34,6 +34,8 @@
  */
 
 
+#ifndef SJ3_RK_H_
+#define SJ3_RK_H_
 
 #include <sys/types.h>
 #include "wchar16.h"
@@ -80,3 +82,4 @@ typedef	struct rktable {
 	struct rktable *next;
 } RkTabl;
 
+#endif /* SJ3_RK_H_ */

--- a/rk.h
+++ b/rk.h
@@ -64,7 +64,7 @@
 #define	RKZEN		0xff00
 
 #define SetMojilen(c)	(((c) << 16) & 0x00ff0000)
-#define GetMojilen(c)	(((c) & ERRCODE) ? (1) : (((c) >> 16) & 0xff)) 
+#define GetMojilen(c)	(((c) & ERRCODE) ? (1) : (((c) >> 16) & 0xff))
 
 typedef	struct rktable_w16 {
 	wchar16_t *r_key;

--- a/rk_conv.c
+++ b/rk_conv.c
@@ -120,7 +120,7 @@ static wchar16_t *shp;
 static YmibufRec ymipbuf, *ymipp;
 static unsigned short *yhp;
 
-
+/* rk_conv.c */
 int sj3_rkinit_mb(char *);
 char *getkey(char *, wchar16_t *, int *);
 char *rkgetyomi(char *, wchar16_t *, int *);
@@ -128,7 +128,7 @@ void cltable(void);
 int chk_rstr(wchar16_t *, wchar16_t *, int, int);
 int stradd(wchar16_t **, wchar16_t *, int);
 int kstradd(wchar16_t **, wchar16_t *, int);
-RkTablW16 *mktable(wchar16_t *key, int len);
+RkTablW16 *mktable(wchar16_t *, int);
 void sj3_rkclear(void);
 void sj3_rkreset(void);
 int sj3_rkconv2(wchar16_t *, unsigned int *, int);
@@ -136,6 +136,7 @@ int sj3_rkinit_sub(char *, int (*)(void));
 int sj3_rkconv_w16(wchar16_t *, wchar16_t *);
 int rkmatch(wchar16_t *, wchar16_t *, int);
 
+/* wc16_str.c */
 int sj3_wslen16(wchar16_t *);
 int sj3_wscmp16(wchar16_t *, wchar16_t *);
 int sj3_wsncmp16(wchar16_t *, wchar16_t *, int);

--- a/rk_conv.c
+++ b/rk_conv.c
@@ -1039,7 +1039,7 @@ int sj3_rkconv2(wchar16_t *wstr, unsigned int *kstr, int wlen)
 
 
 
-int sj3_rkconv(wchar16_t *romaji, wchar16_t *kana)
+int sj3_rkconv(unsigned char *romaji, unsigned char *kana)
 {
 	wchar16_t *wstr;
 	int len, mflag = 0, ret;
@@ -1132,7 +1132,7 @@ int sj3_rkconv_mb(unsigned char *romaji, unsigned char *kana)
 	if (current_locale == LC_CTYPE_EUC)
 	  return sj3_rkconv_euc(romaji, kana);
 	else
-	  return sj3_rkconv((wchar16_t *)romaji, (wchar16_t *)kana);
+	  return sj3_rkconv(romaji, kana);
 }
 
 int sj3_rkconv_w16(wchar16_t *wstr, wchar16_t *kstr)

--- a/rk_conv.c
+++ b/rk_conv.c
@@ -1092,7 +1092,7 @@ int sj3_rkconv(wchar16_t *romaji, wchar16_t *kana)
 		return -1;
 	}
 	if (current_locale == LC_CTYPE_EUC) {
-		len = euctosjis(kana, MAXLLEN*2, mtmp, sizeof(mtmp));
+		len = euctosjis((unsigned char *)kana, MAXLLEN*2, mtmp, sizeof(mtmp));
 	} else {
 		(void) memcpy(kana, mtmp, strlen((char *)mtmp) + 1);
 	}
@@ -1154,7 +1154,7 @@ int sj3_rkconv_mb(unsigned char *romaji, unsigned char *kana)
 	if (current_locale == LC_CTYPE_EUC)
 	  return sj3_rkconv_euc(romaji, kana);
 	else
-	  return sj3_rkconv(romaji, kana);
+	  return sj3_rkconv((wchar16_t *)romaji, (wchar16_t *)kana);
 }
 
 int sj3_rkconv_w16(wchar16_t *wstr, wchar16_t *kstr)

--- a/rk_conv.c
+++ b/rk_conv.c
@@ -50,6 +50,7 @@ static char rcsid[] = "$Header: /export/work/contrib/sj3/sj3rkcv/RCS/rk_conv.c,v
 #include "kctype.h"
 #include "rk.h"
 #include "sj3lib.h"
+#include "Funcs.h"
 
 #if defined(__sony_news) && defined(SVR4)
 #define wscmp sj3_wscmp16
@@ -119,30 +120,6 @@ static StrbufRec strpbuf, *strpp;
 static wchar16_t *shp;
 static YmibufRec ymipbuf, *ymipp;
 static unsigned short *yhp;
-
-/* rk_conv.c */
-int sj3_rkinit_mb(char *);
-char *getkey(char *, wchar16_t *, int *);
-char *rkgetyomi(char *, wchar16_t *, int *);
-void cltable(void);
-int chk_rstr(wchar16_t *, wchar16_t *, int, int);
-int stradd(wchar16_t **, wchar16_t *, int);
-int kstradd(wchar16_t **, wchar16_t *, int);
-RkTablW16 *mktable(wchar16_t *, int);
-void sj3_rkclear(void);
-void sj3_rkreset(void);
-int sj3_rkconv2(wchar16_t *, unsigned int *, int);
-int sj3_rkinit_sub(char *, int (*)(void));
-int sj3_rkconv_w16(wchar16_t *, wchar16_t *);
-int rkmatch(wchar16_t *, wchar16_t *, int);
-
-/* wc16_str.c */
-int sj3_wslen16(wchar16_t *);
-int sj3_wscmp16(wchar16_t *, wchar16_t *);
-int sj3_wsncmp16(wchar16_t *, wchar16_t *, int);
-wchar16_t *sj3_wscpy16(wchar16_t *, wchar16_t *);
-int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
-int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
 
 
 void sj3_rkcode(int code)

--- a/romaji.c
+++ b/romaji.c
@@ -41,7 +41,9 @@
 
 extern int rkerrbell;
 
-
+unsigned short sj_zen2han(unsigned short);
+unsigned short sj_addten(unsigned short prefix, unsigned short c);
+unsigned short sj_han2zen(unsigned short c);
 
 exec_romaji(c)
 wchar16_t	c;

--- a/server.h
+++ b/server.h
@@ -54,7 +54,7 @@ int get_word(void);
 int get_int(void);
 #endif
 int get_nstring(unsigned char *p, int n);
-unsigned char *get_ndata(unsigned char *p, int n);
+void *get_ndata(void *p, int n);
 
 /* error.c */
 int open_debug(void);

--- a/server.h
+++ b/server.h
@@ -60,17 +60,10 @@ void *get_ndata(void *p, int n);
 int open_debug(void);
 int open_error(void);
 int open_log(void);
-#if 0
-void error_out(char *s, int p1, int p2, int p3, int p4, int p5);
-void warning_out(char *s, int p1, int p2, int p3, int p4, int p5);
-void logging_out(char *s, int p1, int p2, int p3, int p4, int p5);
-void debug_out(int lvl, char *s, int p1, int p2, int p3, int p4, int p5);
-#else /* correct solution is to make the functions take arbitrary parameters... */
-void error_out ();
-void warning_out ();
-void logging_out ();
-void debug_out ();
-#endif
+void error_out (char *s, ...);
+void warning_out (char *s, ...);
+void logging_out (char *s, ...);
+void debug_out (int lvl, char *s, ...);
 
 /* execute.c */
 int make_full_path(char *path);

--- a/setup.c
+++ b/setup.c
@@ -101,8 +101,7 @@ static	int	line_number;
 
 #ifdef	OLD
 #else /* !OLD */
-void
-RcError(char* p)
+void RcError(char* p)
 {
 	fprintf(stderr, "%s: \"%s\", line %d: %s\r\n",
 		program_name, runcmd_file, line_number, p);
@@ -110,8 +109,7 @@ RcError(char* p)
 	exit(1);
 }
 
-void
-RcWarning(char* p)
+void RcWarning(char* p)
 {
 	fprintf(stderr, "%s: warning: \"%s\", line %d: %s\r\n",
 		program_name, runcmd_file, line_number, p);
@@ -120,8 +118,7 @@ RcWarning(char* p)
 #endif /* !OLD */
 
 
-static int
-cmpstr(unsigned char* src, unsigned char* dst)
+static int cmpstr(unsigned char* src, unsigned char* dst)
 {
 	int	flg;
 	int	c;
@@ -139,9 +136,7 @@ cmpstr(unsigned char* src, unsigned char* dst)
 
 
 
-static	unsigned char	*get_str(p, pv_dst)
-unsigned char	*p;
-void	*pv_dst;
+static	unsigned char	*get_str(unsigned char *p, void *pv_dst)
 {
 	char		**dst;
 
@@ -154,9 +149,8 @@ void	*pv_dst;
 	while (*p++) ;
 	return p;
 }
-static	unsigned char	*get_int(p, pv_dst)
-unsigned char	*p;
-void	*pv_dst;
+
+static	unsigned char	*get_int(unsigned char *p, void *pv_dst)
 {
 	char	*fmt;
 	int		*dst;
@@ -167,9 +161,8 @@ void	*pv_dst;
 	while (*p++) ;
 	return p;
 }
-static	unsigned char	*get_flag(p, pv_dst)
-unsigned char	*p;
-void	*pv_dst;
+
+static	unsigned char	*get_flag(unsigned char *p, void *pv_dst)
 {
 	int		*dst;
 
@@ -187,8 +180,7 @@ void	*pv_dst;
 }
 
 
-static unsigned char*
-get_list(unsigned char* p, StrList** dst)
+static unsigned char* get_list(unsigned char* p, StrList** dst)
 {
 	StrList	*s1, *s2;
 
@@ -283,8 +275,7 @@ struct	optlist {
 
 
 
-static	int	skip_blank(fp)
-FILE	*fp;
+static	int	skip_blank(FILE *fp)
 {
 	int	c;
 
@@ -292,8 +283,8 @@ FILE	*fp;
 	while (c == ' ' || c == '\t') c = getc(fp);
 	return c;
 }
-static	int	skip_line(fp)
-FILE	*fp;
+
+static	int	skip_line(FILE *fp)
 {
 	int	c;
 
@@ -301,10 +292,8 @@ FILE	*fp;
 	while (c != '\n' && c != EOF) c = getc(fp);
 	return c;
 }
-static	int	readln(fp, p, len)
-FILE	*fp;
-char	*p;
-int	len;		
+
+static	int	readln(FILE *fp, char *p, int len)
 {
 	int	c;
 	int	quote = EOF;
@@ -359,8 +348,7 @@ int	len;
 	return c;
 }
 
-int
-read_line(FILE* fp, char* buf, int len)
+int read_line(FILE* fp, char* buf, int len)
 {
 	int	flg;
 
@@ -374,8 +362,7 @@ read_line(FILE* fp, char* buf, int len)
 
 
 
-void
-read_runcmd(void)
+void read_runcmd(void)
 {
 	FILE	*fp;
 	unsigned char	buf[BUFSIZ];
@@ -404,8 +391,7 @@ read_runcmd(void)
 }
 
 
-static void
-set_defstr(char** d, char* s)
+static void set_defstr(char** d, char* s)
 {
 	if (*d == NULL && s) {
 		*d = malloc(strlen(s) + 1);
@@ -415,15 +401,13 @@ set_defstr(char** d, char* s)
 }
 
 
-static void
-set_defint(int* d, int s)
+static void set_defint(int* d, int s)
 {
 	if (*d < 0) *d = s;
 }
 
 
-void
-set_default(void)
+void set_default(void)
 {
 	set_defstr(&debug_file,		DebugOutFile);
 	set_defstr(&error_file,		ErrorOutFile);
@@ -451,8 +435,7 @@ set_default(void)
 }
 
 
-void
-parse_arg(int argc, char** argv)
+void parse_arg(int argc, char** argv)
 {
 	int	c;
 	int	errflg = 0;
@@ -488,8 +471,7 @@ parse_arg(int argc, char** argv)
 }
 
 
-void
-preload_dict(void)
+void preload_dict(void)
 {
 	StrList	*p;
 	char	filename[PathNameLen];
@@ -516,8 +498,7 @@ preload_dict(void)
 	free(work_base);
 }
 
-void
-preopen_dict(void)
+void preopen_dict(void)
 {
 	StrList	*p;
 	char	filename[PathNameLen];
@@ -554,8 +535,7 @@ preopen_dict(void)
 }
 
 
-static int
-str_match(char* s, char* d)
+static int str_match(char* s, char* d)
 {
 	while (*d) {
 		if (*s == '*') {
@@ -575,8 +555,7 @@ str_match(char* s, char* d)
 }
 
 
-int
-check_user(char* user, char* host)
+int check_user(char* user, char* host)
 {
 	StrList	*p;
 

--- a/setup.c
+++ b/setup.c
@@ -301,7 +301,7 @@ FILE	*fp;
 	while (c != '\n' && c != EOF) c = getc(fp);
 	return c;
 }
-static	readln(fp, p, len)
+static	int	readln(fp, p, len)
 FILE	*fp;
 char	*p;
 int	len;		

--- a/sj3_rkcv.c
+++ b/sj3_rkcv.c
@@ -166,17 +166,21 @@ static unsigned short HZtbl[95] = {
 	0xa3f8, 0xa3f9, 0xa3fa, 0xa1d0, 0xa1c3, 0xa1d1, 0xa1b1
 };
 
-RkTablW16 *mktable(wchar16_t *, int);
+/* rk_conv.c */
 int kstradd(wchar16_t **, wchar16_t *, int);
-int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
-int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
-int sj3_wslen16(wchar16_t *);
+RkTablW16 *mktable(wchar16_t *, int);
 
+/* sj3_rkcv.c */
 int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
 int sj_hantozen(wchar16_t *, wchar16_t *, int);
 unsigned short sj_zen2han(unsigned short);
 int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
 int sj_zentohan(wchar16_t *, wchar16_t *, int);
+
+/* wc16_str.c */
+int sj3_wslen16(wchar16_t *);
+int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
+int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
 
 #ifdef ADDHK
 void setl_hktozh(void)

--- a/sj3_rkcv.c
+++ b/sj3_rkcv.c
@@ -41,6 +41,7 @@
 #include "rk.h"
 #include "kctype.h"
 #include "sj3lib.h"
+#include "Funcs.h"
 
 #if defined(__sony_news) && (SVR4)
 #define wscmp sj3_wscmp16
@@ -165,22 +166,6 @@ static unsigned short HZtbl[95] = {
 	0xa3f0, 0xa3f1, 0xa3f2, 0xa3f3, 0xa3f4, 0xa3f5, 0xa3f6, 0xa3f7,
 	0xa3f8, 0xa3f9, 0xa3fa, 0xa1d0, 0xa1c3, 0xa1d1, 0xa1b1
 };
-
-/* rk_conv.c */
-int kstradd(wchar16_t **, wchar16_t *, int);
-RkTablW16 *mktable(wchar16_t *, int);
-
-/* sj3_rkcv.c */
-int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
-int sj_hantozen(wchar16_t *, wchar16_t *, int);
-unsigned short sj_zen2han(unsigned short);
-int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
-int sj_zentohan(wchar16_t *, wchar16_t *, int);
-
-/* wc16_str.c */
-int sj3_wslen16(wchar16_t *);
-int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
-int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
 
 #ifdef ADDHK
 void setl_hktozh(void)

--- a/sj3_rkcv.c
+++ b/sj3_rkcv.c
@@ -40,6 +40,7 @@
 #include "kana.h"
 #include "rk.h"
 #include "kctype.h"
+#include "sj3lib.h"
 
 #if defined(__sony_news) && (SVR4)
 #define wscmp sj3_wscmp16
@@ -165,14 +166,26 @@ static unsigned short HZtbl[95] = {
 	0xa3f8, 0xa3f9, 0xa3fa, 0xa1d0, 0xa1c3, 0xa1d1, 0xa1b1
 };
 
+RkTablW16 *mktable(wchar16_t *, int);
+int kstradd(wchar16_t **, wchar16_t *, int);
+int sj3_mbstowcs16(wchar16_t *, unsigned char *, int);
+int sj3_wcstombs16(unsigned char *, wchar16_t *, int);
+int sj3_wslen16(wchar16_t *);
+
+int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
+int sj_hantozen(wchar16_t *, wchar16_t *, int);
+unsigned short sj_zen2han(unsigned short);
+int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
+int sj_zentohan(wchar16_t *, wchar16_t *, int);
+
 #ifdef ADDHK
-setl_hktozh()
+void setl_hktozh(void)
 {
 	int i;
 	unsigned short c, zen1;
 	wchar16_t rstr[2];
 	wchar16_t kstr[2];
-	RkTablW16 *rktp, *mktable();
+	RkTablW16 *rktp;
 
 	zen1 = (ZHIRA1 << 8);
 	rstr[1] = '\0';
@@ -204,12 +217,12 @@ setl_hktozh()
 #endif
 
 
-mkkigou()
+void mkkigou(void)
 {
 	int i;
 	wchar16_t rstr[2];
 	wchar16_t kstr[2];
-	RkTablW16 *rktp, *mktable();
+	RkTablW16 *rktp;
 
 	rstr[1] = '\0';
 	kstr[1] = 0;
@@ -225,8 +238,7 @@ mkkigou()
 	}
 }
 			
-sj_addten(prefix, c)
-unsigned short prefix, c;
+unsigned short sj_addten(unsigned short prefix, unsigned short c)
 {
 	unsigned short c1, cc;
 
@@ -246,8 +258,7 @@ unsigned short prefix, c;
 	return(cc);
 }
 
-sj_han2zen(c)
-unsigned short c;
+unsigned short sj_han2zen(unsigned short c)
 {
 	int i;
 	unsigned short cc;
@@ -286,10 +297,7 @@ unsigned short c;
 }
 
 
-int sj3_hantozen_w16(wchar16_t *, wchar16_t *);
-
-sj3_hantozen(out, in)
-unsigned char *out, *in;
+int sj3_hantozen(unsigned char *out, unsigned char *in)
 {
 	wchar16_t *winstr, *woutstr;
 	unsigned char *mstr;
@@ -381,8 +389,7 @@ unsigned char *out, *in;
 	}
 }
 
-sj3_hantozen_euc(out, in)
-unsigned char *out, *in;
+int sj3_hantozen_euc(unsigned char *out, unsigned char *in)
 {
 	wchar16_t *winstr, *woutstr;
 	unsigned char *mstr;
@@ -474,8 +481,7 @@ unsigned char *out, *in;
 	}
 }
 
-sj3_hantozen_mb(s1, s2)
-unsigned char *s1, *s2;
+int sj3_hantozen_mb(unsigned char *s1, unsigned char *s2)
 {
 	if (current_locale == LC_CTYPE_EUC) 
 	  return sj3_hantozen_euc(s1, s2);
@@ -483,16 +489,13 @@ unsigned char *s1, *s2;
   	  return sj3_hantozen(s1, s2);
 }
 
-int sj3_hantozen_w16(s1, s2)
-wchar16_t *s1, *s2;
+int sj3_hantozen_w16(wchar16_t *s1, wchar16_t *s2)
 {
 	return sj_hantozen(s1, s2, wslen(s2));
 }
 
 
-sj_hantozen(s1, s2, len)
-wchar16_t *s1, *s2;
-int len;
+int sj_hantozen(wchar16_t *s1, wchar16_t *s2, int len)
 {
 	unsigned short c1, cc, prefix;
 	wchar16_t c;
@@ -524,8 +527,7 @@ int len;
 	return(rlen);
 }
 
-sj_zen2han(c)
-unsigned short c;
+unsigned short sj_zen2han(unsigned short c)
 {
 	int i;
 	unsigned short cc;
@@ -559,10 +561,7 @@ unsigned short c;
 	return(cc);
 }
 
-int sj3_zentohan_w16(wchar16_t *, wchar16_t *);
-
-sj3_zentohan(out, in)
-unsigned char *out, *in;
+int sj3_zentohan(unsigned char *out, unsigned char *in)
 {
 	wchar16_t *winstr, *woutstr;
 	unsigned char *mstr;
@@ -651,8 +650,7 @@ unsigned char *out, *in;
 	return ret;
 }
 
-sj3_zentohan_euc(out, in)
-unsigned char *out, *in;
+int sj3_zentohan_euc(unsigned char *out, unsigned char *in)
 {
 	wchar16_t *winstr, *woutstr;
 	unsigned char *mstr;
@@ -742,8 +740,7 @@ unsigned char *out, *in;
 	return ret;
 }
 
-sj3_zentohan_mb(s1, s2)
-unsigned char *s1, *s2;
+int sj3_zentohan_mb(unsigned char *s1, unsigned char *s2)
 {
 	if (current_locale == LC_CTYPE_EUC)
 	  return sj3_zentohan_euc(s1, s2);
@@ -751,15 +748,12 @@ unsigned char *s1, *s2;
 	  return sj3_zentohan(s1, s2);
 }
 
-int sj3_zentohan_w16 (s1, s2)
-wchar16_t *s1, *s2;
+int sj3_zentohan_w16 (wchar16_t *s1, wchar16_t *s2)
 {
 	return sj_zentohan(s1, s2, wslen(s2));
 }
 
-sj_zentohan(s1, s2, len)
-wchar16_t *s1, *s2;
-int len;
+int sj_zentohan(wchar16_t *s1, wchar16_t *s2, int len)
 {
 	unsigned short cc;
 	wchar16_t c;
@@ -791,8 +785,7 @@ int len;
 	return(rlen);
 }
 
-sj_tokata(c)
-wchar16_t c;
+wchar16_t sj_tokata(wchar16_t c)
 {
 	if (sj_ishira(c)) {
 		c += 0x0100;
@@ -800,8 +793,7 @@ wchar16_t c;
 	return(c);
 }
 
-sj_tohira(c)
-wchar16_t c;
+wchar16_t sj_tohira(wchar16_t c)
 {
 	if (sj_iskata(c) && (short) c <= (short) 0xa5f3) {
 		c -= 0x0100;
@@ -809,8 +801,7 @@ wchar16_t c;
 	return(c);
 }
 
-sj_htok(s1, s2)
-wchar16_t *s1, *s2;
+void sj_htok(wchar16_t *s1, wchar16_t *s2)
 {
 	wchar16_t cc;
 	wchar16_t c;
@@ -825,8 +816,7 @@ wchar16_t *s1, *s2;
 	*s1 = (wchar16_t) '\0';
 }
 
-sj_ktoh(s1, s2)
-wchar16_t *s1, *s2;
+void sj_ktoh(wchar16_t *s1, wchar16_t *s2)
 {
 	wchar16_t cc;
 	wchar16_t c;

--- a/sj3dic.c
+++ b/sj3dic.c
@@ -49,18 +49,7 @@
 #include "sj3lib.h"
 #include "sj3dic.h"
 #include "server.h"
-
-/* codecnv.c */
-int init_code(void);
-
-/* dictdisp.c */
-void dictdisp(char *output);
-
-/* dictmake.c */
-void  dictmake(char *input);
-
-/* sjrc.c */
-int getsjrc(void);
+#include "Funcs.h"
 
 static void _open_error(int err);
 static void _close_error(int err);

--- a/sj3dic.c
+++ b/sj3dic.c
@@ -50,9 +50,17 @@
 #include "sj3dic.h"
 #include "server.h"
 
+/* codecnv.c */
+int init_code(void);
 
-int init_code(void), getsjrc(void);
-void dictdisp(char *output), dictmake(char *input);
+/* dictdisp.c */
+void dictdisp(char *output);
+
+/* dictmake.c */
+void  dictmake(char *input);
+
+/* sjrc.c */
+int getsjrc(void);
 
 static void _open_error(int err);
 static void _close_error(int err);
@@ -97,8 +105,7 @@ int	init_flag = 0;
 int	force_flag = 0;
 
 
-int
-main(int argc, char** argv)
+int main(int argc, char** argv)
 {
 	int	err;
 	int	mode;
@@ -133,8 +140,7 @@ main(int argc, char** argv)
 	if ((err = sj3_close())) _close_error(err);
 }
 
-static void
-init_env(void)
+static void init_env(void)
 {
 	char	*un, *hp, *tn;
 	struct	passwd	*pwd;
@@ -167,8 +173,7 @@ init_env(void)
 	strcpy(term_name, tn);
 }
 
-static void
-usage(int ret)
+static void usage(int ret)
 {
 	fprintf(stderr,
 		"Usage: %s -{text|dict} [-H host_name] [file_name]\n",
@@ -176,8 +181,7 @@ usage(int ret)
 	exit(ret);
 }
 
-static int
-parsearg(int argc, char* argv[])
+static int parsearg(int argc, char* argv[])
 {
 	int	errflg = 0;
 	int	i, j;
@@ -246,8 +250,7 @@ parsearg(int argc, char* argv[])
 	return mode;
 }
 
-static void
-make_dicname(void)
+static void make_dicname(void)
 {
 	if (dict_name[0] != '\0') return;
 
@@ -256,16 +259,14 @@ make_dicname(void)
 	strcat(dict_name, "sj2usr.dic");
 }
 
-void
-setdicname(char* dictname)
+void setdicname(char* dictname)
 {
 	if (dict_name[0] != '\0') return;
 	if (dictname == NULL) return;
 	strcpy(dict_name, dictname);
 }
 
-void
-setsjserv(char* hostname)
+void setsjserv(char* hostname)
 {
 	if (serv_name[0] != '\0') return;
 	if (hostname == NULL) return;
@@ -278,8 +279,7 @@ struct	errlist	{
 	int	flg;
 };
 
-static void
-_error_and(int err, struct errlist* list)
+static void _error_and(int err, struct errlist* list)
 {
 	int	flag = 0;
 
@@ -294,8 +294,7 @@ _error_and(int err, struct errlist* list)
 	if (flag) exit(1);
 }
 
-static void
-_open_error(int err)
+static void _open_error(int err)
 {
 	static	struct	errlist	err_msg[] = {
 	{ SJ3_SERVER_DEAD,	"\245\265\241\274\245\320\244\254\273\340\244\363\244\307\244\244\244\336\244\271",			1 },
@@ -314,8 +313,7 @@ _open_error(int err)
 	_error_and(err, err_msg);
 }
 
-static void
-_close_error(int err)
+static void _close_error(int err)
 {
 	static	struct	errlist	err_msg[] = {
 	{ SJ3_SERVER_DEAD,	"\245\265\241\274\245\320\241\274\244\254\273\340\244\363\244\307\244\244\244\336\244\271",		1 },

--- a/sj3dic.c
+++ b/sj3dic.c
@@ -48,7 +48,11 @@
 #include "sjtool.h"
 #include "sj3lib.h"
 #include "sj3dic.h"
+#include "server.h"
 
+
+int init_code(void), getsjrc(void);
+void dictdisp(char *output), dictmake(char *input);
 
 static void _open_error(int err);
 static void _close_error(int err);

--- a/sj3err.c
+++ b/sj3err.c
@@ -39,6 +39,8 @@
 #include <stdio.h>
 #include "sj3err.h"
 
+void printout();
+
 void
 sj3error(fp, code)
 FILE	*fp;

--- a/sj3err.c
+++ b/sj3err.c
@@ -38,13 +38,9 @@
 
 #include <stdio.h>
 #include "sj3err.h"
+#include "Funcs.h"
 
-void printout();
-
-void
-sj3error(fp, code)
-FILE	*fp;
-int	code;
+void sj3error(FILE *fp, int code)
 {
 	unsigned char	tmp[BUFSIZ];
 

--- a/sj3lib.c
+++ b/sj3lib.c
@@ -66,8 +66,7 @@ static unsigned char buf1[YomiBufSize];
 static unsigned char buf2[YomiBufSize];
 static unsigned char kbuf[KanjiBufSize];
 
-static int
-set_sys_code(void)
+static int set_sys_code(void)
 {
 	char *loc;
 
@@ -78,8 +77,7 @@ set_sys_code(void)
 	return SYS_EUC;
 }
 
-static int
-make_dirs(char *path)
+static int make_dirs(char *path)
 {
 	char	 tmp[PathNameLen];
 	char	*p;
@@ -102,8 +100,7 @@ make_dirs(char *path)
 	return 0;
 }
 
-int
-sj3_open(char *host, char *user)
+int sj3_open(char *host, char *user)
 {
 	char	 tmp[PathNameLen];
 	char	*p;
@@ -187,9 +184,7 @@ server_dead:
 	return SJ3_SERVER_DEAD;
 }
 
-int
-sj3_open_with_list(char *host, char *user, int dicts_num,
-    char **dicts, int *error_num, int **error_index)
+int sj3_open_with_list(char *host, char *user, int dicts_num, char **dicts, int *error_num, int **error_index)
 {
 	char	 tmp[PathNameLen];
 	char	*p;
@@ -309,8 +304,7 @@ server_dead:
 	return SJ3_SERVER_DEAD;
 }
 
-int
-sj3_close(void)
+int sj3_close(void)
 {
 	int	err = SJ3_NORMAL_END;
 	int	i;
@@ -381,8 +375,7 @@ server_dead:
 	return SJ3_SERVER_DEAD;
 }
 
-int
-sj3_getkan(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
+int sj3_getkan(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
 {
 	unsigned char	*src;
 	int	 buncnt = 0;
@@ -436,8 +429,7 @@ sj3_getkan(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz
 	return buncnt;
 }
 
-int
-sj3_getkan_euc(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
+int sj3_getkan_euc(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
 {
 	unsigned char		*src, *yp, *kp, *khp;
 	int		 buncnt = 0, i;
@@ -538,8 +530,7 @@ sj3_getkan_euc(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int kn
 	return buncnt;
 }
 
-int
-sj3_getkan_mb(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
+int sj3_getkan_mb(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knjsiz)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -549,8 +540,7 @@ sj3_getkan_mb(unsigned char *yomi, SJ3_BUNSETU *bun, unsigned char *knj, int knj
 		return sj3_getkan(yomi, bun, knj, knjsiz);
 }
 
-int
-sj3_douoncnt(unsigned char *yomi)
+int sj3_douoncnt(unsigned char *yomi)
 {
 	int	i;
 
@@ -570,8 +560,7 @@ sj3_douoncnt(unsigned char *yomi)
 	return i;
 }
 
-int
-sj3_douoncnt_euc(unsigned char *yomi)
+int sj3_douoncnt_euc(unsigned char *yomi)
 {
 	int	 i, l, flag;
 	unsigned char	*yp;
@@ -604,8 +593,7 @@ sj3_douoncnt_euc(unsigned char *yomi)
 	return i;
 }
 
-int
-sj3_douoncnt_mb(unsigned char *yomi)
+int sj3_douoncnt_mb(unsigned char *yomi)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -615,8 +603,7 @@ sj3_douoncnt_mb(unsigned char *yomi)
 		return sj3_douoncnt(yomi);
 }
 
-int
-sj3_getdouon(unsigned char *yomi, SJ3_DOUON *dou)
+int sj3_getdouon(unsigned char *yomi, SJ3_DOUON *dou)
 {
 	int	i;
 
@@ -635,8 +622,7 @@ sj3_getdouon(unsigned char *yomi, SJ3_DOUON *dou)
 	return i;
 }
 
-int
-sj3_getdouon_euc(unsigned char *yomi, SJ3_DOUON *dou)
+int sj3_getdouon_euc(unsigned char *yomi, SJ3_DOUON *dou)
 {
 	int	i, j, l;
 
@@ -679,8 +665,7 @@ sj3_getdouon_euc(unsigned char *yomi, SJ3_DOUON *dou)
 	return i;
 }
 
-int
-sj3_getdouon_mb(unsigned char *yomi, SJ3_DOUON *dou)
+int sj3_getdouon_mb(unsigned char *yomi, SJ3_DOUON *dou)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -690,8 +675,7 @@ sj3_getdouon_mb(unsigned char *yomi, SJ3_DOUON *dou)
 		return sj3_getdouon(yomi, dou);
 }
 
-int
-sj3_gakusyuu(SJ3_STUDYREC *dcid)
+int sj3_gakusyuu(SJ3_STUDYREC *dcid)
 {
 	if (sj3_tango_gakusyuu(&client, dcid) == ERROR) {
 		if (client.fd < 0) {
@@ -703,8 +687,7 @@ sj3_gakusyuu(SJ3_STUDYREC *dcid)
 	return 0;
 }
 
-int
-sj3_gakusyuu2(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
+int sj3_gakusyuu2(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
 {
 	if (sj3_bunsetu_gakusyuu(&client, yomi1, yomi2, dcid, MBCODE_SJIS) ==
 	    ERROR) {
@@ -717,8 +700,7 @@ sj3_gakusyuu2(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
 	return 0;
 }
 
-int
-sj3_gakusyuu2_euc(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
+int sj3_gakusyuu2_euc(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
 {
 	int l, flag;
 	unsigned char *y1p, *y2p;
@@ -752,8 +734,7 @@ sj3_gakusyuu2_euc(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid
 	return 0;
 }
 
-int
-sj3_gakusyuu2_mb(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
+int sj3_gakusyuu2_mb(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -763,8 +744,7 @@ sj3_gakusyuu2_mb(unsigned char *yomi1, unsigned char *yomi2, SJ3_STUDYREC *dcid)
 		return sj3_gakusyuu2(yomi1, yomi2, dcid);
 }
 
-int
-sj3_touroku(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_touroku(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	if (sj3_tango_touroku(&client, udicid, yomi, kanji, code,
 	    MBCODE_SJIS)) {
@@ -790,8 +770,7 @@ sj3_touroku(unsigned char *yomi, unsigned char *kanji, int code)
 	return 0;
 }
 
-int
-sj3_touroku_euc(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_touroku_euc(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	int l, flag;
 	unsigned char *yp;
@@ -838,8 +817,7 @@ sj3_touroku_euc(unsigned char *yomi, unsigned char *kanji, int code)
 	return 0;
 }
 
-int
-sj3_touroku_mb(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_touroku_mb(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -849,8 +827,7 @@ sj3_touroku_mb(unsigned char *yomi, unsigned char *kanji, int code)
 		return sj3_touroku(yomi, kanji, code);
 }
 
-int
-sj3_syoukyo(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_syoukyo(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	if (sj3_tango_sakujo(&client, udicid, yomi, kanji, code, MBCODE_SJIS)) {
 		if (client.fd < 0) {
@@ -871,8 +848,7 @@ sj3_syoukyo(unsigned char *yomi, unsigned char *kanji, int code)
 	return 0;
 }
 
-int
-sj3_syoukyo_euc(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_syoukyo_euc(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	int l, flag;
 	unsigned char *yp;
@@ -915,8 +891,7 @@ sj3_syoukyo_euc(unsigned char *yomi, unsigned char *kanji, int code)
 	return 0;
 }
 
-int
-sj3_syoukyo_mb(unsigned char *yomi, unsigned char *kanji, int code)
+int sj3_syoukyo_mb(unsigned char *yomi, unsigned char *kanji, int code)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -926,8 +901,7 @@ sj3_syoukyo_mb(unsigned char *yomi, unsigned char *kanji, int code)
 		return sj3_syoukyo(yomi, kanji, code);
 }
 
-int
-sj3_getdict(unsigned char *buf)
+int sj3_getdict(unsigned char *buf)
 {
 	if (sj3_tango_syutoku(&client, udicid, buf, MBCODE_SJIS)) {
 		if (client.fd < 0) {
@@ -939,8 +913,7 @@ sj3_getdict(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_getdict_euc(unsigned char *buf)
+int sj3_getdict_euc(unsigned char *buf)
 {
 	int l, ll, slen;
 
@@ -981,8 +954,7 @@ sj3_getdict_euc(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_getdict_mb(unsigned char *buf)
+int sj3_getdict_mb(unsigned char *buf)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -992,8 +964,7 @@ sj3_getdict_mb(unsigned char *buf)
 		return sj3_getdict(buf);
 }
 
-int
-sj3_nextdict(unsigned char *buf)
+int sj3_nextdict(unsigned char *buf)
 {
 	if (sj3_tango_jikouho(&client, udicid, buf, MBCODE_SJIS)) {
 		if (client.fd < 0) {
@@ -1005,8 +976,7 @@ sj3_nextdict(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_nextdict_euc(unsigned char *buf)
+int sj3_nextdict_euc(unsigned char *buf)
 {
 	int l, ll, slen;
 
@@ -1047,8 +1017,7 @@ sj3_nextdict_euc(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_nextdict_mb(unsigned char *buf)
+int sj3_nextdict_mb(unsigned char *buf)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -1058,8 +1027,7 @@ sj3_nextdict_mb(unsigned char *buf)
 		return sj3_nextdict(buf);
 }
 
-int
-sj3_prevdict(unsigned char *buf)
+int sj3_prevdict(unsigned char *buf)
 {
 	if (sj3_tango_maekouho(&client, udicid, buf, MBCODE_SJIS)) {
 		if (client.fd < 0) {
@@ -1071,8 +1039,7 @@ sj3_prevdict(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_prevdict_euc(unsigned char *buf)
+int sj3_prevdict_euc(unsigned char *buf)
 {
 	int l, ll, slen;
 
@@ -1113,8 +1080,7 @@ sj3_prevdict_euc(unsigned char *buf)
 	return 0;
 }
 
-int
-sj3_prevdict_mb(unsigned char *buf)
+int sj3_prevdict_mb(unsigned char *buf)
 {
 	if (_sys_code == SYS_NOTDEF)
 		_sys_code = set_sys_code();
@@ -1124,8 +1090,7 @@ sj3_prevdict_mb(unsigned char *buf)
 		return sj3_prevdict(buf);
 }
 
-int
-sj3_lockserv(void)
+int sj3_lockserv(void)
 {
 	if (sj3_lock_server(&client) == ERROR) {
 		if (client.fd < 0) {
@@ -1137,8 +1102,7 @@ sj3_lockserv(void)
 	return 0;
 }
 
-int
-sj3_unlockserv(void)
+int sj3_unlockserv(void)
 {
 	if (sj3_unlock_server(&client)) {
 		if (client.fd < 0) {

--- a/sj3lib.c
+++ b/sj3lib.c
@@ -55,7 +55,7 @@ static int     _sys_code = SYS_NOTDEF;
 
 char			*sj3_user_dir = "user";
 static char		*path_delimiter = "/";
-static SJ3_CLIENT_ENV	 client = { -1, 0 };
+static SJ3_CLIENT_ENV	 client = { -1, 0, 0, 0, 0, {0, 0} };
 static long		 mdicid = 0;
 static long		 udicid = 0;
 static int		 defuse = 0;

--- a/sj_struct.h
+++ b/sj_struct.h
@@ -42,8 +42,8 @@
 #include <sys/types.h>
 #include "sj_typedef.h"
 
-typedef	struct	jiritu {
-	struct jiritu	*jsort;		
+typedef	struct	jrec {
+	struct jrec	*jsort;		
 	TypeDicSeg	jseg;		
 	TypeDicOfs	jofsst;		
 	TypeDicOfs	jofsed;		
@@ -61,9 +61,9 @@ typedef	struct	jiritu {
 
 
 
-typedef struct bunsetu {
+typedef struct clrec {
 	JREC	*jnode;			
-	struct	bunsetu	*clsort;	
+	struct	clrec	*clsort;	
 	unsigned char	gobiln;
 	unsigned char	cllen;
 
@@ -80,7 +80,7 @@ typedef struct bunsetu {
 
 
 
-typedef	struct	kouho {
+typedef	struct	khrec {
 	CLREC		*clrec;		
 	TypeDicOfs	offs;		
 	TypeStyNum	styno;		
@@ -103,7 +103,7 @@ typedef	struct	kouho {
 
 
 
-typedef	struct	conj {
+typedef	struct	crec {
 	unsigned char	len;
 	TypeCnct	right;		
 } CREC;
@@ -111,7 +111,7 @@ typedef	struct	conj {
 
 
 
-typedef	struct	fuzoku {
+typedef	struct	frec {
 	unsigned char	*yomip;
 	unsigned char	*fzkp;
 
@@ -119,7 +119,7 @@ typedef	struct	fuzoku {
 
 
 
-typedef struct study_in {
+typedef struct stdyin {
 	TypeDicOfs	offset;		
 	TypeDicSeg	seg;		
 	TypeStyNum	styno;		
@@ -138,7 +138,7 @@ typedef struct study_in {
 
 
 
-typedef struct study_out {
+typedef struct stdyout {
 	STDYIN		stdy1;		
 	TypeGram	hinshi;		
 	unsigned char	len;

--- a/sj_struct.h
+++ b/sj_struct.h
@@ -43,7 +43,7 @@
 #include "sj_typedef.h"
 
 typedef	struct	jrec {
-	struct jrec	*jsort;		
+	struct jrec	*jsort;
 	TypeDicSeg	jseg;		
 	TypeDicOfs	jofsst;		
 	TypeDicOfs	jofsed;		
@@ -63,7 +63,7 @@ typedef	struct	jrec {
 
 typedef struct clrec {
 	JREC	*jnode;			
-	struct	clrec	*clsort;	
+	struct	clrec	*clsort;
 	unsigned char	gobiln;
 	unsigned char	cllen;
 

--- a/sjrc.c
+++ b/sjrc.c
@@ -38,11 +38,14 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <locale.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include "sjctype.h"
 #include "sjtool.h"
+#include "sj3dic.h"
+#include "sj3lib.h"
 
 struct wordent {
 	char	word_str[MAXWORD];
@@ -60,11 +63,13 @@ static int	user_euc = 0;
 static int	file_code = SYS_SJIS;	
 
 void	setrc();
-int	set_dict(), set_server();
+void	set_dict(), set_server();
+int	getword(), much();
+int	IsTerminator(), isTerminator(), IsEscape(), IsDelimitor();
 
 struct functbl {
 	char *keyword;
-	int (*func)();
+	void (*func)();
 } funcs[] = {
 	{"dictionary",	set_dict},
 	{"userdic",	set_dict},
@@ -306,14 +311,14 @@ unsigned char	c;
 	return (c == ' ' || c == '\t' || c == '.') ? 1 : 0;
 }
 
-int
+void
 set_dict (word)
 struct wordent	word[];
 {
 	setdicname(word[1].word_str);
 }
 
-int
+void
 set_server(word)
 struct wordent	word[];
 {

--- a/sjrc.c
+++ b/sjrc.c
@@ -62,10 +62,16 @@ static char	*rcfile = ".sjrc";
 static int	user_euc = 0;
 static int	file_code = SYS_SJIS;	
 
-void	setrc();
-void	set_dict(), set_server();
-int	getword(), much();
-int	IsTerminator(), isTerminator(), IsEscape(), IsDelimitor();
+/* sjrc.c */
+void setrc(char *, FILE *);
+int much(char *, char *);
+int getword(char *, struct wordent[]);
+int IsTerminator(unsigned char);
+int isTerminator(unsigned char);
+int IsEscape(unsigned char);
+int IsDelimitor(unsigned char);
+void set_dict(struct wordent[]);
+void set_server(struct wordent[]);
 
 struct functbl {
 	char *keyword;
@@ -79,8 +85,7 @@ struct functbl {
 
 #define TOLOWER(c) (isupper(c) ? tolower(c) : (c))	
 
-int
-sjset_code()
+int sjset_code (void)
 {
 	char *loc;
 
@@ -113,8 +118,7 @@ sjset_code()
 }
 	
 
-int
-getsjrc ()
+int getsjrc (void)
 {
 	FILE *fd;
 	char *p;
@@ -148,10 +152,7 @@ getsjrc ()
 }
 
 
-void
-setrc (file, fd)
-char	*file;
-FILE	*fd;
+void setrc (char *file, FILE *fd)
 {
 	char		line[MAXLINE];
 	int	w;
@@ -175,9 +176,7 @@ FILE	*fd;
 }
 
 
-int
-much(s1, s2)
-char *s1, *s2;
+int much(char *s1, char *s2)
 {
 	char c1, c2;
 
@@ -193,10 +192,7 @@ char *s1, *s2;
 }
 
 
-int
-getword (s, word)
-char	*s;
-struct wordent	word[];
+int getword (char *s, struct wordent word[])
 {
 	unsigned char	c, cc;
 	char *p;
@@ -283,44 +279,32 @@ struct wordent	word[];
 	return wcount;
 }
 
-int
-IsTerminator (c)
-unsigned char	c;
+int IsTerminator (unsigned char c)
 {
 	return (c == '\n') ? 1 : 0;
 }
 
-int
-isTerminator (c)
-unsigned char	c;
+int isTerminator (unsigned char c)
 {
 	return (c == '#') ? 1 : 0;
 }
 
-int
-IsEscape (c)
-unsigned char	c;
+int IsEscape (unsigned char c)
 {
 	return (c == '\\') ? 1 : 0;
 }
 
-int
-IsDelimitor (c)
-unsigned char	c;
+int IsDelimitor (unsigned char c)
 {
 	return (c == ' ' || c == '\t' || c == '.') ? 1 : 0;
 }
 
-void
-set_dict (word)
-struct wordent	word[];
+void set_dict (struct wordent word[])
 {
 	setdicname(word[1].word_str);
 }
 
-void
-set_server(word)
-struct wordent	word[];
+void set_server(struct wordent word[])
 {
 	setsjserv(word[1].word_str);
 }

--- a/sjrc.c
+++ b/sjrc.c
@@ -46,6 +46,7 @@
 #include "sjtool.h"
 #include "sj3dic.h"
 #include "sj3lib.h"
+#include "Funcs.h"
 
 struct wordent {
 	char	word_str[MAXWORD];
@@ -63,13 +64,7 @@ static int	user_euc = 0;
 static int	file_code = SYS_SJIS;	
 
 /* sjrc.c */
-void setrc(char *, FILE *);
-int much(char *, char *);
 int getword(char *, struct wordent[]);
-int IsTerminator(unsigned char);
-int isTerminator(unsigned char);
-int IsEscape(unsigned char);
-int IsDelimitor(unsigned char);
 void set_dict(struct wordent[]);
 void set_server(struct wordent[]);
 

--- a/string.c
+++ b/string.c
@@ -104,7 +104,7 @@ sj3_str_euctosjis(unsigned char *out, int outlen, unsigned char *in,
 {
 	unsigned char *euc = in, *sjis = out;
 	int n = 0;
-	unsigned short code, default_code;
+	unsigned short code;
 
 	sjis[0] = '\0';
 	*useflag = 0;

--- a/string.c
+++ b/string.c
@@ -51,9 +51,7 @@
 #define iseuc(c)     ((0xa1 <= (c)) && ((c) <= 0xfe))
 #define iskana(c)   ((0xa1 <= (c)) && ((c) <= 0xdf))
 
-int
-sj3_str_sjistoeuc(unsigned char *out, int outlen, unsigned char *in,
-    unsigned char *sjis_default, int *useflag)
+int sj3_str_sjistoeuc(unsigned char *out, int outlen, unsigned char *in, unsigned char *sjis_default, int *useflag)
 {
 	unsigned char *sjis = in, *euc = out;
 	int n = 0;
@@ -98,9 +96,7 @@ sj3_str_sjistoeuc(unsigned char *out, int outlen, unsigned char *in,
 	return n;
 }
 
-int
-sj3_str_euctosjis(unsigned char *out, int outlen, unsigned char *in,
-    unsigned char *sjis_default, int *useflag)
+int sj3_str_euctosjis(unsigned char *out, int outlen, unsigned char *in, unsigned char *sjis_default, int *useflag)
 {
 	unsigned char *euc = in, *sjis = out;
 	int n = 0;
@@ -148,8 +144,7 @@ sj3_str_euctosjis(unsigned char *out, int outlen, unsigned char *in,
 	return n;
 }
 
-int
-sj3_sjistoeuclen(unsigned char *str, int max)
+int sj3_sjistoeuclen(unsigned char *str, int max)
 {
 	int len = 0, bytes = 1;
 
@@ -178,32 +173,28 @@ sj3_sjistoeuclen(unsigned char *str, int max)
 
 static unsigned char def_char[] = {0x81, 0x40};
 
-int
-sj3_sjistoeuc(unsigned char *e, int elen, unsigned char *s, int slen)
+int sj3_sjistoeuc(unsigned char *e, int elen, unsigned char *s, int slen)
 {
 	int dummy;
 
 	return sj3_str_sjistoeuc(e, elen, s, def_char, &dummy);
 }
 
-int
-sj3_euctosjis(unsigned char *s, int slen, unsigned char *e, int elen)
+int sj3_euctosjis(unsigned char *s, int slen, unsigned char *e, int elen)
 {
 	int dummy;
 
 	return sj3_str_euctosjis(s, slen, e, def_char, &dummy);
 }
 
-void
-sj_euc2sjis(unsigned char *s)
+void sj_euc2sjis(unsigned char *s)
 {
 	s[0] &= MASK;
 	s[1] &= MASK;
 	sj_jis2sjis(s);
 }
 
-void
-sj_jis2sjis(unsigned char *s)
+void sj_jis2sjis(unsigned char *s)
 {
 	int    high, low;
 	int    nh, nl;
@@ -223,16 +214,14 @@ sj_jis2sjis(unsigned char *s)
 	s[1] = nl;
 }
 
-void
-sj_sjis2euc(unsigned char *s)
+void sj_sjis2euc(unsigned char *s)
 {
 	sj_sjis2jis(s);
 	s[0] |= MSB;
 	s[1] |= MSB;
 }
 
-void
-sj_sjis2jis(unsigned char *s)
+void sj_sjis2jis(unsigned char *s)
 {
 	int byte1, byte2;
 	unsigned char *sp;
@@ -257,8 +246,7 @@ sj_sjis2jis(unsigned char *s)
 	}
 }
 
-unsigned short
-sj3_jis2sjis(unsigned short code)
+unsigned short sj3_jis2sjis(unsigned short code)
 {
 	unsigned char tmp[3];
 
@@ -273,8 +261,7 @@ sj3_jis2sjis(unsigned short code)
 	return (code);
 }
 
-unsigned short
-sj3_jis2euc(unsigned short code)
+unsigned short sj3_jis2euc(unsigned short code)
 {
 	unsigned char tmp[3];
 
@@ -287,8 +274,7 @@ sj3_jis2euc(unsigned short code)
 	return (code);
 }
 
-unsigned short
-sj3_sjis2jis(unsigned short code)
+unsigned short sj3_sjis2jis(unsigned short code)
 {
 	unsigned char tmp[3];
 
@@ -303,8 +289,7 @@ sj3_sjis2jis(unsigned short code)
 	return (code);
 }
 
-unsigned short
-sj3_euc2sjis(unsigned short code)
+unsigned short sj3_euc2sjis(unsigned short code)
 {
 	unsigned char tmp[3];
 
@@ -319,8 +304,7 @@ sj3_euc2sjis(unsigned short code)
 	return (code);
 }
 
-unsigned short
-sj3_sjis2euc(unsigned short code)
+unsigned short sj3_sjis2euc(unsigned short code)
 {
 	unsigned char tmp[3];
 

--- a/wakachi.c
+++ b/wakachi.c
@@ -41,12 +41,17 @@
 #include "sj_hinsi.h"
 #include "kanakan.h"
 
-int	terminate();
-void	setclrec(), srchfzk();
-void	free_jall();
+/* fuzoku.c */
+void setclrec(JREC *, unsigned char *, TypeCnct);
+void srchfzk(JREC *, unsigned char *, TypeCnct, int);
 
-void
-wakachi (void)
+/* memory2.c */
+void free_jall(JREC *);
+
+/* terminat.c */
+int terminate(TypeCnct, unsigned char *);
+
+void wakachi (void)
 {
 	JREC		*jrec;
 	CLREC		*clrec;

--- a/wakachi.c
+++ b/wakachi.c
@@ -43,6 +43,7 @@
 
 int	terminate();
 void	setclrec(), srchfzk();
+void	free_jall();
 
 void
 wakachi (void)

--- a/wakachi.c
+++ b/wakachi.c
@@ -40,16 +40,7 @@
 #include "sj_right.h"
 #include "sj_hinsi.h"
 #include "kanakan.h"
-
-/* fuzoku.c */
-void setclrec(JREC *, unsigned char *, TypeCnct);
-void srchfzk(JREC *, unsigned char *, TypeCnct, int);
-
-/* memory2.c */
-void free_jall(JREC *);
-
-/* terminat.c */
-int terminate(TypeCnct, unsigned char *);
+#include "Funcs.h"
 
 void wakachi (void)
 {

--- a/wc16_str.c
+++ b/wc16_str.c
@@ -42,6 +42,7 @@
 #if defined(__sony_news) && defined(SVR4)
 #include <sonyils.h>
 #endif
+#include "sj3lib.h"
 
 #define MSB 0x80
 
@@ -298,7 +299,7 @@ int n;
 	
 	while (*ws && (i < n)) {
 		code = sj3_wc2euc16(*ws);
-		if (c = ((code >> 16) & 0xff)) {
+		if ((c = ((code >> 16) & 0xff))) {
 			*mb++ = c;
 			i++;
 			if (i == n) break;
@@ -308,14 +309,14 @@ int n;
 			*mb++ = code & 0xff;
 		        i++;
 			if (i == n) break;
-		} else if (c = ((code >> 8) & 0xff)) {
+		} else if ((c = ((code >> 8) & 0xff))) {
 			*mb++ = c;
 			i++;
 			if (i == n) break;
 			*mb++ = code & 0xff;
 		        i++;
 			if (i == n) break;
-		} else if (c = (code & 0xff)) {
+		} else if ((c = (code & 0xff))) {
 			*mb++ = c;
 			i++;
 		} else {
@@ -343,14 +344,14 @@ int n;
 	
 	while (*ws && (i < n)) {
 		code = sj3_wc2sjis16(*ws);
-		if (c = ((code >> 8) & 0xff)) {
+		if ((c = ((code >> 8) & 0xff))) {
 			*mb++ = c;
 			i++;
 			if (i == n) break;
 			*mb++ = code & 0xff;
 			i++;
 			if (i == n) break;
-		} else if (c = (code & 0xff)) {
+		} else if ((c = (code & 0xff))) {
 			*mb++ = c;
 			i++;
 		} else {

--- a/wc16_str.c
+++ b/wc16_str.c
@@ -63,18 +63,14 @@
 
 extern int current_locale;
 
-int 
-sj3_iswcntrl16(wc)
-wchar16_t wc;
+int sj3_iswcntrl16(wchar16_t wc)
 {
 	if ((wc < 0x20) || (wc == 0x7f)) return TRUE;
 
 	return FALSE;
 }
 
-int 
-sj3_iswupper16(wc)
-wchar16_t wc;
+int  sj3_iswupper16(wchar16_t wc)
 {
 	if (((0x40 < wc) && (wc < 0x5b)) || 
 	    ((0xa3c0 < wc) && (wc < 0xa3db))) return TRUE;
@@ -82,9 +78,7 @@ wchar16_t wc;
 	return FALSE;
 }
 
-int 
-sj3_iswdigit16(wc)
-wchar16_t wc;
+int sj3_iswdigit16(wchar16_t wc)
 {
 	if (((0x29 < wc) && (wc < 0x3a)) || 
 	    ((0xa3af < wc) && (wc < 0xa3ba))) return TRUE;
@@ -92,9 +86,7 @@ wchar16_t wc;
 	return FALSE;
 }
 
-int 
-sj3_iswxdigit16(wc)
-wchar16_t wc;
+int sj3_iswxdigit16(wchar16_t wc)
 {
 	if (((0x29 < wc) && (wc < 0x3a)) || 
 	    ((0xa3af < wc) && (wc < 0xa3ba))) return TRUE;
@@ -108,9 +100,7 @@ wchar16_t wc;
 	return FALSE;
 }
 
-int
-sj3_wslen16(ws)
-wchar16_t *ws;
+int sj3_wslen16(wchar16_t *ws)
 {
 	int i=0;
 
@@ -120,9 +110,7 @@ wchar16_t *ws;
 	return i;
 }
 
-int
-sj3_wscmp16(ws1, ws2)
-wchar16_t *ws1, *ws2;
+int sj3_wscmp16(wchar16_t *ws1, wchar16_t *ws2)
 {
 	while ((*ws1 && *ws2) && (*ws1 == *ws2)) {
 		ws1++;
@@ -135,10 +123,7 @@ wchar16_t *ws1, *ws2;
 	return  1;
 }
 
-int 
-sj3_wsncmp16(ws1, ws2, n)
-wchar16_t *ws1, *ws2;
-int n;
+int sj3_wsncmp16(wchar16_t *ws1, wchar16_t *ws2, int n)
 {
 	int i=0;
 
@@ -155,9 +140,7 @@ int n;
 	return 1;
 }
 
-wchar16_t *
-sj3_wscpy16(ws1, ws2)
-wchar16_t *ws1, *ws2;
+wchar16_t *sj3_wscpy16(wchar16_t *ws1, wchar16_t *ws2)
 {
 	wchar16_t *ws;
 
@@ -171,10 +154,7 @@ wchar16_t *ws1, *ws2;
 	return ws1;
 }
 
-wchar16_t *
-sj3_wsncpy16(ws1, ws2, n)
-wchar16_t *ws1, *ws2;
-int n;
+wchar16_t *sj3_wsncpy16(wchar16_t *ws1, wchar16_t *ws2, int n)
 {
 	wchar16_t *ws;
 	int i=0;
@@ -190,9 +170,7 @@ int n;
 	return ws1;
 }
 
-wchar16_t *
-sj3_wscat16(ws1, ws2)
-wchar16_t *ws1, *ws2;
+wchar16_t *sj3_wscat16(wchar16_t *ws1, wchar16_t *ws2)
 {
 	wchar16_t *ws;
 
@@ -211,9 +189,7 @@ wchar16_t *ws1, *ws2;
 }
 
 
-wchar16_t
-sj3_euc2wc16(code)
-unsigned int code;
+wchar16_t sj3_euc2wc16(unsigned int code)
 {
 	wchar16_t wc = 0;
 
@@ -228,9 +204,7 @@ unsigned int code;
 	return wc;
 }
 		
-wchar16_t 
-sj3_sjis2wc16(code)
-unsigned int code;
+wchar16_t sj3_sjis2wc16(unsigned int code)
 {
 	unsigned short ch;
 
@@ -244,9 +218,7 @@ unsigned int code;
 	return (sj3_euc2wc16(ch));
 }
 
-unsigned int
-sj3_wc2euc16(wc)
-wchar16_t wc;
+unsigned int sj3_wc2euc16(wchar16_t wc)
 {
 	unsigned int code = 0;
 	unsigned char tmp;
@@ -269,9 +241,7 @@ wchar16_t wc;
 	return code;
 }
 
-unsigned int
-sj3_wc2sjis16(wc)
-wchar16_t wc;
+unsigned int sj3_wc2sjis16(wchar16_t wc)
 {
 	unsigned int ch;
 
@@ -287,11 +257,7 @@ wchar16_t wc;
 	}
 }
 
-int
-sj3_wcs2eucs16(mb, ws, n)
-unsigned char *mb;
-wchar16_t *ws;
-int n;
+int sj3_wcs2eucs16(unsigned char *mb, wchar16_t *ws, int n)
 {
 	int i = 0;
 	unsigned int code;
@@ -332,11 +298,7 @@ int n;
 	return i;
 }
 	
-int
-sj3_wcs2sjiss16(mb, ws, n)
-unsigned char *mb;
-wchar16_t *ws;
-int n;
+int sj3_wcs2sjiss16(unsigned char *mb, wchar16_t *ws, int n)
 {
 	int i = 0;
 	unsigned int code;
@@ -367,11 +329,7 @@ int n;
 	return i;
 }
 
-int 
-sj3_eucs2wcs16(ws, mb, n)
-wchar16_t *ws;
-unsigned char *mb;
-int n;
+int sj3_eucs2wcs16(wchar16_t *ws, unsigned char *mb, int n)
 {
 	int i = 0;
 	unsigned int code;
@@ -399,11 +357,7 @@ int n;
 	return i;
 }
 
-int
-sj3_sjiss2wcs16(ws, mb, n)
-wchar16_t *ws;
-unsigned char *mb;
-int n;
+int sj3_sjiss2wcs16(wchar16_t *ws, unsigned char *mb, int n)
 {
 	int i = 0;
 	unsigned int code;
@@ -427,11 +381,7 @@ int n;
 	return i;
 }
 
-int
-sj3_mbstowcs16(ws, mb, n)
-wchar16_t *ws;
-unsigned char *mb;
-int n;
+int sj3_mbstowcs16(wchar16_t *ws, unsigned char *mb, int n)
 {
 	if (current_locale == LC_CTYPE_EUC)
 	  return sj3_eucs2wcs16(ws, mb, n);
@@ -439,11 +389,7 @@ int n;
 	  return sj3_sjiss2wcs16(ws, mb, n);
 }
 
-int
-sj3_wcstombs16(mb, ws, n)
-unsigned char *mb;
-wchar16_t *ws;
-int n;
+int sj3_wcstombs16(unsigned char *mb, wchar16_t *ws, int n)
 {
 	if (current_locale == LC_CTYPE_EUC)
 	  return sj3_wcs2eucs16(mb, ws, n);


### PR DESCRIPTION
-Wimplicit-function-declarationを主体に修正しています。
sj3_rkcv.c, rk_conv.cについてはANSI化も行っています（rk_conv.cはANSI化に伴いimcompatible-pointer-typeのwarningが新たに発生していますが、これは今後修正を考えることにします）。

ファイルの外に定義された関数の参照を行うための宣言をあちこちに追加していますが、ANSI化を行う際に適当なヘッダファイルへ追い出した方が良いのではないかと考えています。

makeでコンパイルされるものについてのみ作業が済んでいますが、make allでコンパイルされるものについては未修正で、これも今後対応が必要です。